### PR TITLE
Fixing Variables in foreign functions not unifiable

### DIFF
--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -154,8 +154,11 @@ class Variable(object):
             fun = PL_unify_list
         else:
             raise
-
-        t = PL_new_term_ref()
+	
+	if self.handle is None:
+		t = PL_new_term_ref(self.handle)
+	else
+        	t = PL_copy_term_ref(self.handle)
         fun(t, value)
         self.handle = t
 


### PR DESCRIPTION
When using Variable in foreign_functions, the Unification did not change anything on the Variable.
This was also reproducable in examples/register_foreign.py where the output was:

python examples/register_foreign.py 
[{'Y': Variable(68), 'X': 'Python'}]

After patching it yield as expected:
[{'Y': 130, 'X': 'Python'}]
