### PR TITLE
Added hardcoded path for libswipl.so

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -254,7 +254,7 @@ def _findSwiplLin():
         return (path, swiHome)
 
     # Our last try: some hardcoded paths.
-    paths = ['/lib', '/usr/lib', '/usr/local/lib', '.', './lib']
+    paths = ['/lib', '/usr/lib', '/usr/local/lib', '.', './lib', '/usr/lib/swi-prolog/lib/x86_64-linux']
     names = ['libswipl.so', 'libpl.so']
 
     path = None


### PR DESCRIPTION
The path added was where the so file was found when installing from swi-prolog/stable apt repo on __Ubuntu 18.04__