### PR TITLE
Bugfix on core.py

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -82,9 +82,9 @@ def _findSwiplFromExec():
 
         # We may have pl or swipl as the executable
         try:
-            cmd = Popen(['swipl', '-dump-runtime-variables'], stdout=PIPE)
+            cmd = Popen(['swipl', '--dump-runtime-variables'], stdout=PIPE)
         except OSError:
-            cmd = Popen(['pl', '-dump-runtime-variables'], stdout=PIPE)
+            cmd = Popen(['pl', '--dump-runtime-variables'], stdout=PIPE)
         ret = cmd.communicate()
 
         # Parse the output into a dictionary


### PR DESCRIPTION
I followed by @rylanchiu here https://github.com/yuce/pyswip/issues/35#issue-331136546 when having errors with the MacOS installation test example. It turns out there were missing hyphens in the arguments to the Popen for swipl. Now that example works for me.