### PR TITLE
For SWI-Prolog 8 and onward, PLSOEXT usage is erroneous on MacOS.

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -122,7 +122,7 @@ def _findSwiplFromExec():
                     fullName = None
 
             elif platform == "dar":
-                dllName = 'lib' + rtvars['PLLIB'][2:] + '.' + rtvars['PLSOEXT']
+                dllName = 'lib' + rtvars['PLLIB'][2:] + '.' + "dylib"
                 path = os.path.join(rtvars['PLBASE'], 'lib', rtvars['PLARCH'])
                 baseName = os.path.join(path, dllName)
 


### PR DESCRIPTION
For SWI-Prolog v7.x.x, PLSOEXT reported `dylib`. However, for v8.x.x, this is reported as `so`. 

On MacOS, `so` is reserved for _modules_ (like e.g. `prolog_stream.so`, `json.so`, `tex.so` in `...libexec/lib/swipl/lib/<arch>/`). Dynamic libraries _always_ have the extending `dylib`.

This should be hardcoded in. Currently, if you have SWI-Prolog 8.x.x on MacOS, it will not be able to find `libswipl.dylib` and ask for input for the version number. It _does_ find the SWI home path, but it is unable to find the library because it is erroneously looking for `libswipl.so`.