### PR TITLE
Update nosignal cli parameter to fix latest swipl support

### DIFF
--- a/pyswip/prolog.py
+++ b/pyswip/prolog.py
@@ -47,7 +47,7 @@ def _initialize():
     args = []
     args.append("./")
     args.append("-q")         # --quiet
-    args.append("-nosignals") # "Inhibit any signal handling by Prolog"
+    args.append("--no-signals") # "Inhibit any signal handling by Prolog"
     if SWI_HOME_DIR is not None:
         args.append("--home=%s" % SWI_HOME_DIR)
 

--- a/pyswip/prolog.py
+++ b/pyswip/prolog.py
@@ -47,7 +47,7 @@ def _initialize():
     args = []
     args.append("./")
     args.append("-q")         # --quiet
-    args.append("--no-signals") # "Inhibit any signal handling by Prolog"
+    args.append("--nosignals") # "Inhibit any signal handling by Prolog"
     if SWI_HOME_DIR is not None:
         args.append("--home=%s" % SWI_HOME_DIR)
 


### PR DESCRIPTION
Fixes #66 
In the latest versions the cli parameter is changed from 
-nosignal to --no-signals

**EDIT**: The proper parameter is --nosignals