### PR TITLE
Prologrules macos patch 1

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -338,9 +338,8 @@ def _findSwiplMacOSHome():
         path = os.environ.get('SWI_LIB_DIR')
         if path is None:
             path = os.environ.get('PLBASE')
-            if path is None:
-                swi_ver = get_swi_ver()
-                path = '/Applications/SWI-Prolog.app/Contents/swipl-' + swi_ver + '/lib/'
+            if path is None:                
+                path = '/Applications/SWI-Prolog.app/Contents/'
     
     paths = [path]
 


### PR DESCRIPTION
Enabling MacOS to find libswipl.dylib for any version of swipl (also fixing the fallback directory searching mechanism since the swipl version number is not part of the path).