### PR TITLE
Support multibyte strings and atoms

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -616,6 +616,10 @@ PL_POINTER = 13  # void *
 #define PL_MBCODES   (35)       /* const char * */
 #define PL_MBSTRING  (36)       /* const char * */
 
+REP_ISO_LATIN_1 = 0x0000 # output representation
+REP_UTF8 = 0x1000
+REP_MB = 0x2000
+
 #       /********************************
 #       * NON-DETERMINISTIC CALL/RETURN *
 #       *********************************/
@@ -766,6 +770,10 @@ PL_discard_foreign_frame = _lib.PL_discard_foreign_frame
 PL_discard_foreign_frame.argtypes = [fid_t]
 PL_discard_foreign_frame.restype = None
 
+PL_put_chars = _lib.PL_put_chars
+PL_put_chars.argtypes = [term_t, c_int, c_size_t, c_char_p]
+PL_put_chars.restype = c_int
+
 PL_put_list_chars = _lib.PL_put_list_chars
 PL_put_list_chars.argtypes = [term_t, c_char_p]
 PL_put_list_chars.restype = c_int
@@ -815,6 +823,8 @@ PL_get_string_chars.argtypes = [term_t, POINTER(c_char_p), c_int_p]
 
 #PL_EXPORT(int)         PL_get_chars(term_t t, char **s, unsigned int flags);
 PL_get_chars = _lib.PL_get_chars  # FIXME:
+PL_get_chars.argtypes = [term_t, POINTER(c_char_p), c_uint]
+PL_get_chars.restype = c_int
 
 PL_get_chars = check_strings(None, 1)(PL_get_chars)
 
@@ -887,6 +897,10 @@ PL_put_atom_chars = check_strings(1, None)(PL_put_atom_chars)
 PL_atom_chars = _lib.PL_atom_chars
 PL_atom_chars.argtypes = [atom_t]
 PL_atom_chars.restype = c_char_p
+
+PL_atom_wchars = _lib.PL_atom_wchars
+PL_atom_wchars.argtypes = [atom_t, POINTER(c_size_t)]
+PL_atom_wchars.restype = c_wchar_p
 
 PL_predicate = _lib.PL_predicate
 PL_predicate.argtypes = [c_char_p, c_int, c_char_p]

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -45,7 +45,7 @@ class ArgumentTypeError(Exception):
 class Atom(object):
     __slots__ = "handle", "chars"
 
-    def __init__(self, handleOrChars):
+    def __init__(self, handleOrChars, chars=None):
         """Create an atom.
         ``handleOrChars``: handle or string of the atom.
         """
@@ -56,8 +56,11 @@ class Atom(object):
         else:
             self.handle = handleOrChars
             PL_register_atom(self.handle)
-            #self.chars = c_char_p(PL_atom_chars(self.handle)).value
-            self.chars = PL_atom_chars(self.handle)
+            if chars is None:
+                slen = c_size_t()
+                self.chars = PL_atom_wchars(self.handle, byref(slen))
+            else: # WA: PL_atom_wchars can fail to return correct string
+                self.chars = chars
 
     def fromTerm(cls, term):
         """Create an atom from a Term or term handle."""
@@ -69,7 +72,7 @@ class Atom(object):
 
         a = atom_t()
         if PL_get_atom(term, byref(a)):
-            return cls(a.value)
+            return cls(a.value, getAtomChars(term))
     fromTerm = classmethod(fromTerm)
 
     def __del__(self):
@@ -142,7 +145,7 @@ class Variable(object):
             self.handle = handle
             s = create_string_buffer(b"\00"*64)  # FIXME:
             ptr = cast(s, c_char_p)
-            if PL_get_chars(handle, byref(ptr), CVT_VARIABLE|BUF_RING):
+            if PL_get_chars(handle, byref(ptr), CVT_VARIABLE|BUF_RING|REP_UTF8):
                 self.chars = ptr.value
         else:
             self.handle = PL_new_term_ref()
@@ -329,12 +332,11 @@ def putList(l, ls):
         PL_cons_list(l, a, l)
 
 
-# deprecated
 def getAtomChars(t):
     """If t is an atom, return it as a string, otherwise raise InvalidTypeError.
     """
     s = c_char_p()
-    if PL_get_atom_chars(t, byref(s)):
+    if PL_get_chars(t, byref(s), CVT_ATOM|REP_UTF8):
         return s.value
     else:
         raise InvalidTypeError("atom")
@@ -382,9 +384,8 @@ def getFloat(t):
 def getString(t):
     """If t is of type string, return it, otherwise raise InvalidTypeError.
     """
-    slen = c_int()
     s = c_char_p()
-    if PL_get_string_chars(t, byref(s), byref(slen)):
+    if PL_get_chars(t, byref(s), REP_UTF8|CVT_STRING):
         return s.value
     else:
         raise InvalidTypeError("string")

--- a/pyswip/prolog.py
+++ b/pyswip/prolog.py
@@ -95,7 +95,7 @@ class Prolog:
             swipl_goalCharList = swipl_args
             swipl_bindingList = swipl_args + 1
 
-            PL_put_list_chars(swipl_goalCharList, query)
+            PL_put_chars(swipl_goalCharList, PL_STRING|REP_UTF8, -1, query.encode("utf-8"))
 
             swipl_predicate = PL_predicate("pyrun", 2, None)
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -231,6 +231,27 @@ class TestIssues(unittest.TestCase):
         self.assertTrue(args[0] == args[2], "The first and last var of "
                                             "f([A, B, A]) should be the same")
 
+    def test_issue_62(self):
+        """
+        Problem with non-ascii atoms and strings
+
+        https://github.com/yuce/pyswip/issues/62
+        """
+        from pyswip import Prolog
+
+        prolog = Prolog()
+        prolog.consult("tests/test_unicode.pl", catcherrors=True)
+        atoms = list(prolog.query("unicode_atom(B)."))
+
+        self.assertEqual(len(atoms), 3,
+                         "Query should return exactly three atoms")
+
+        strings = list(prolog.query("unicode_string(B)."))
+
+        self.assertEqual(len(strings), 1,
+                         "Query should return exactly one string")
+        self.assertEqual(strings[0]['B'], b'\xd1\x82\xd0\xb5\xd1\x81\xd1\x82')
+
     def test_functor_return(self):
         """
         pyswip should generate string representations of query results

--- a/tests/test_unicode.pl
+++ b/tests/test_unicode.pl
@@ -1,0 +1,7 @@
+:- encoding(utf8).
+
+unicode_atom('peñarol').
+unicode_atom('franišek').
+unicode_atom('bonifác').
+
+unicode_string("тест").


### PR DESCRIPTION
* pyswip/core.py: Add functions required to work with UTF-8 encoded symbols.
* pyswip/easy.py (`Atom.__init__`): Use `PL_atom_wchars` to get string representation of the atom. Unfortunately `PL_atom_wchars` can fail on some strings. e.g. second definition of `father` predicate from https://github.com/Hefaist/test_pyswip/blob/master/utf_facts.pl leads to "ValueError: character U+ffffffe1 is not in range [U+0000; U+10ffff]" error. Allow to pass correct string instead as a workaround.
  (`Atom.fromTerm`): Pass atom string representation extracted from `term_t` to Atom constructor.
  (`Variable.__init__`): Ask for a UTF-8 string.
  (`getAtomChars`): Ask for a UTF-8 string. Remove "deprecated" comment still this function required for `Atom.fromTerm` function.
  (`getString`): Ask for a UTF-8 string.
* pyswip/prolog.py (`Prolog._QueryWrapper.__call__`): Specify that we'll send UTF-8 string to prolog.