### PR TITLE
Compat8.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 dist/
 pyswip.egg-info/
 build/
+/.idea/
+/.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 before_install:
   - sudo apt-add-repository -y ppa:swi-prolog/stable
   - sudo apt-get update
-  - sudo apt-get install -y swi-prolog-nox
+  - sudo apt-get install -y swi-prolog-nox # >=8.2.0
 install:
   - pip install -r test-requirements.txt coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 before_install:
   - sudo apt-add-repository -y ppa:swi-prolog/stable
   - sudo apt-get update
-  - sudo apt-get install -y swi-prolog-nox # >=8.2.0
+  - sudo apt-get install -y swi-prolog-nox # tested up to 8.3.x
 install:
   - pip install -r test-requirements.txt coveralls
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # CHANGELOG
++ 0.3
+  * Synchronized type constants with SWI-Prolog.h
+    update for broken compatibility changes in SWI-Prolog.h.
+    Update to swi-prolog >= 0.8.2 is required (and the default apt
+    for Ubuntu >= 14.04).
+    
+  * Fixed https://github.com/yuce/pyswip/issues/92 (C assert)
+  * Fixed https://github.com/yuce/pyswip/issues/90 (quoted string)
 
 + 0.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
     update for broken compatibility changes in SWI-Prolog.h.
     Update to swi-prolog >= 0.8.2 is required (and the default apt
     for Ubuntu >= 14.04).
-    
+  * Fix incorrect REP_* constants.  
   * Fixed https://github.com/yuce/pyswip/issues/92 (C assert)
   * Fixed https://github.com/yuce/pyswip/issues/90 (quoted string)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # CHANGELOG
 + 0.3
   * Synchronized type constants with SWI-Prolog.h
-    update for broken compatibility changes in SWI-Prolog.h.
-    Update to swi-prolog >= 0.8.2 is required (and the default apt
-    for Ubuntu >= 14.04).
+    update for broken compatibility changes in SWI-Prolog.h up to 0.8.3.
   * Fix incorrect REP_* constants.  
   * Fixed https://github.com/yuce/pyswip/issues/92 (C assert)
   * Fixed https://github.com/yuce/pyswip/issues/90 (quoted string)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -20,3 +20,4 @@ Till Hofmann
 Robert Simione
 rmanhaeve
 Galileo Sartor
+Stuart Reynolds

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Since PySwip uses SWI-Prolog as a shared library and ctypes to access it, it doe
 
 * Python 2.7 or 3.4 and higher.
     * PyPy is currently not supported.
-* SWI-Prolog 7.2.x and higher.
+* SWI-Prolog 8.2.0 and higher.
 * `libswipl` as a shared library. *This is the default on most platforms.*
 * Works on Linux, Windows, MacOS and FreeBSD. Should work on other POSIX.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Since PySwip uses SWI-Prolog as a shared library and ctypes to access it, it doe
 
 * Python 2.7 or 3.4 and higher.
     * PyPy is currently not supported.
-* SWI-Prolog 8.2.0 and higher.
+* SWI-Prolog 7.2.x and higher.
 * `libswipl` as a shared library. *This is the default on most platforms.*
 * Works on Linux, Windows, MacOS and FreeBSD. Should work on other POSIX.
 

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -572,6 +572,28 @@ _fixWindowsPath(_path)
 # Load the library
 _lib = CDLL(_path, mode=RTLD_GLOBAL)
 
+
+PL_version = _lib.PL_version
+PL_version.argtypes = [c_int]
+PL_version.restype = c_uint
+
+#       /*******************************
+#        *	      VERSIONS		*
+#        *******************************/
+
+PL_VERSION_SYSTEM	=1	# Prolog version
+PL_VERSION_FLI		=2	# PL_* compatibility
+PL_VERSION_REC		=3	# PL_record_external() compatibility
+PL_VERSION_QLF		=4	# Saved QLF format version
+PL_VERSION_QLF_LOAD	=5	# Min loadable QLF format version
+PL_VERSION_VM		=6	# VM signature
+PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
+
+PL_VERSION = PL_version(PL_VERSION_SYSTEM)
+if PL_VERSION<80200:
+    raise Exception("swi-prolog>= 8.2.0 is required")
+
+
 # PySwip constants
 PYSWIP_MAXSTR = 1024
 c_int_p = c_void_p
@@ -579,63 +601,109 @@ c_long_p = c_void_p
 c_double_p = c_void_p
 c_uint_p = c_void_p
 
+
+#
 # constants (from SWI-Prolog.h)
 # /* PL_unify_term( arguments */
-PL_VARIABLE     = 1            # nothing
-PL_ATOM         = 2            # const char *
-PL_INTEGER      = 3            # int
-PL_RATIONAL     = 4            # rational number
-PL_FLOAT        = 5            # double
-PL_STRING       = 6            # const char *
-PL_TERM         = 7
-
-PL_NIL          = 8            # The constant []
-PL_BLOB         = 9            # non-atom blob
-PL_LIST_PAIR    = 10           # [_|_] term
-
-# # PL_unify_term(
-PL_FUNCTOR      = 11           # functor_t, arg ...
-PL_LIST         = 12           # length, arg ...
-PL_CHARS        = 13           # const char *
-PL_POINTER      = 14           # void *
-# PlArg::PlArg(text, type
-PL_CODE_LIST    = 15           # [ascii...]
-PL_CHAR_LIST    = 16           # [h,e,l,l,o]
-PL_BOOL         = 17           # PL_set_prolog_flag(
-PL_FUNCTOR_CHARS= 18           # PL_unify_term(
-_PL_PREDICATE_INDICATOR= 19    # predicate_t= Procedure
-PL_SHORT        = 20           # short
-PL_INT          = 21           # int
-PL_LONG         = 22           # long
-PL_DOUBLE       = 23           # double
-PL_NCHARS       = 24           # size_t, const char *
-PL_UTF8_CHARS   = 25           # const char *
-PL_UTF8_STRING  = 26           # const char *
-PL_INT64        = 27           # int64_t
-PL_NUTF8_CHARS  = 28           # size_t, const char *
-PL_NUTF8_CODES  = 29           # size_t, const char *
-PL_NUTF8_STRING = 30           # size_t, const char *
-PL_NWCHARS      = 31           # size_t, const wchar_t *
-PL_NWCODES      = 32           # size_t, const wchar_t *
-PL_NWSTRING     = 33           # size_t, const wchar_t *
-PL_MBCHARS      = 34           # const char *
-PL_MBCODES      = 35           # const char *
-PL_MBSTRING     = 36           # const char *
-PL_INTPTR       = 37           # intptr_t
-PL_CHAR         = 38           # int
-PL_CODE         = 39           # int
-PL_BYTE         = 40           # int
-# PL_skip_list(
-PL_PARTIAL_LIST = 41           # a partial list
-PL_CYCLIC_TERM  = 42           # a cyclic list/term
-PL_NOT_A_LIST   = 43           # Object is not a list
-# dicts
-PL_DICT         = 44
 
 
-REP_ISO_LATIN_1 = 0x0000  # output representation
-REP_UTF8 = 0x00100000
-REP_MB = 0x00200000
+if PL_VERSION<80200:
+    # constants (from SWI-Prolog.h)
+    # PL_unify_term() arguments
+    PL_VARIABLE = 1  # nothing
+    PL_ATOM = 2  # const char
+    PL_INTEGER = 3  # int
+    PL_FLOAT = 4  # double
+    PL_STRING = 5  # const char *
+    PL_TERM = 6  #
+    # PL_unify_term()
+    PL_FUNCTOR = 10  # functor_t, arg ...
+    PL_LIST = 11  # length, arg ...
+    PL_CHARS = 12  # const char *
+    PL_POINTER = 13  # void *
+    #               /* PlArg::PlArg(text, type) */
+    #define PL_CODE_LIST     (14)       /* [ascii...] */
+    #define PL_CHAR_LIST     (15)       /* [h,e,l,l,o] */
+    #define PL_BOOL      (16)       /* PL_set_feature() */
+    #define PL_FUNCTOR_CHARS (17)       /* PL_unify_term() */
+    #define _PL_PREDICATE_INDICATOR (18)    /* predicate_t (Procedure) */
+    #define PL_SHORT     (19)       /* short */
+    #define PL_INT       (20)       /* int */
+    #define PL_LONG      (21)       /* long */
+    #define PL_DOUBLE    (22)       /* double */
+    #define PL_NCHARS    (23)       /* unsigned, const char * */
+    #define PL_UTF8_CHARS    (24)       /* const char * */
+    #define PL_UTF8_STRING   (25)       /* const char * */
+    #define PL_INT64     (26)       /* int64_t */
+    #define PL_NUTF8_CHARS   (27)       /* unsigned, const char * */
+    #define PL_NUTF8_CODES   (29)       /* unsigned, const char * */
+    #define PL_NUTF8_STRING  (30)       /* unsigned, const char * */
+    #define PL_NWCHARS   (31)       /* unsigned, const wchar_t * */
+    #define PL_NWCODES   (32)       /* unsigned, const wchar_t * */
+    #define PL_NWSTRING  (33)       /* unsigned, const wchar_t * */
+    #define PL_MBCHARS   (34)       /* const char * */
+    #define PL_MBCODES   (35)       /* const char * */
+    #define PL_MBSTRING  (36)       /* const char * */
+
+    REP_ISO_LATIN_1 = 0x0000 # output representation
+    REP_UTF8 = 0x1000
+    REP_MB = 0x2000
+
+else:
+    PL_VARIABLE     = 1            # nothing
+    PL_ATOM         = 2            # const char *
+    PL_INTEGER      = 3            # int
+    PL_RATIONAL     = 4            # rational number
+    PL_FLOAT        = 5            # double
+    PL_STRING       = 6            # const char *
+    PL_TERM         = 7
+
+    PL_NIL          = 8            # The constant []
+    PL_BLOB         = 9            # non-atom blob
+    PL_LIST_PAIR    = 10           # [_|_] term
+
+    # # PL_unify_term(
+    PL_FUNCTOR      = 11           # functor_t, arg ...
+    PL_LIST         = 12           # length, arg ...
+    PL_CHARS        = 13           # const char *
+    PL_POINTER      = 14           # void *
+    # PlArg::PlArg(text, type
+    PL_CODE_LIST    = 15           # [ascii...]
+    PL_CHAR_LIST    = 16           # [h,e,l,l,o]
+    PL_BOOL         = 17           # PL_set_prolog_flag(
+    PL_FUNCTOR_CHARS= 18           # PL_unify_term(
+    _PL_PREDICATE_INDICATOR= 19    # predicate_t= Procedure
+    PL_SHORT        = 20           # short
+    PL_INT          = 21           # int
+    PL_LONG         = 22           # long
+    PL_DOUBLE       = 23           # double
+    PL_NCHARS       = 24           # size_t, const char *
+    PL_UTF8_CHARS   = 25           # const char *
+    PL_UTF8_STRING  = 26           # const char *
+    PL_INT64        = 27           # int64_t
+    PL_NUTF8_CHARS  = 28           # size_t, const char *
+    PL_NUTF8_CODES  = 29           # size_t, const char *
+    PL_NUTF8_STRING = 30           # size_t, const char *
+    PL_NWCHARS      = 31           # size_t, const wchar_t *
+    PL_NWCODES      = 32           # size_t, const wchar_t *
+    PL_NWSTRING     = 33           # size_t, const wchar_t *
+    PL_MBCHARS      = 34           # const char *
+    PL_MBCODES      = 35           # const char *
+    PL_MBSTRING     = 36           # const char *
+    PL_INTPTR       = 37           # intptr_t
+    PL_CHAR         = 38           # int
+    PL_CODE         = 39           # int
+    PL_BYTE         = 40           # int
+    # PL_skip_list(
+    PL_PARTIAL_LIST = 41           # a partial list
+    PL_CYCLIC_TERM  = 42           # a cyclic list/term
+    PL_NOT_A_LIST   = 43           # Object is not a list
+    # dicts
+    PL_DICT         = 44
+
+    REP_ISO_LATIN_1 = 0x0000  # output representation
+    REP_UTF8 = 0x00100000
+    REP_MB = 0x00200000
 
 #       /********************************
 #       * NON-DETERMINISTIC CALL/RETURN *
@@ -705,17 +773,6 @@ CVT_EXCEPTION = 0x10000  # throw exception on error
 
 
 
-#       /*******************************
-#        *	      VERSIONS		*
-#        *******************************/
-
-PL_VERSION_SYSTEM	=1	# Prolog version
-PL_VERSION_FLI		=2	# PL_* compatibility
-PL_VERSION_REC		=3	# PL_record_external() compatibility
-PL_VERSION_QLF		=4	# Saved QLF format version
-PL_VERSION_QLF_LOAD	=5	# Min loadable QLF format version
-PL_VERSION_VM		=6	# VM signature
-PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
 
 
 argv = list_to_bytes_list(sys.argv + [None])
@@ -763,13 +820,7 @@ PL_initialise = check_strings(None, 1)(PL_initialise)
 #PL_initialise.argtypes = [c_int, c_c??
 
 #unsigned int PL_version(int key)
-PL_version = _lib.PL_version
-PL_version.argtypes = [c_int]
-PL_version.restype = c_uint
 
-PL_VERSION = PL_version(PL_VERSION_SYSTEM)
-if PL_VERSION<80200:
-    raise Exception("swi-prolog>= 8.2.0 is required")
 
 PL_open_foreign_frame = _lib.PL_open_foreign_frame
 PL_open_foreign_frame.restype = fid_t

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -572,11 +572,6 @@ _fixWindowsPath(_path)
 # Load the library
 _lib = CDLL(_path, mode=RTLD_GLOBAL)
 
-
-PL_version = _lib.PL_version
-PL_version.argtypes = [c_int]
-PL_version.restype = c_uint
-
 #       /*******************************
 #        *	      VERSIONS		*
 #        *******************************/
@@ -589,9 +584,16 @@ PL_VERSION_QLF_LOAD	=5	# Min loadable QLF format version
 PL_VERSION_VM		=6	# VM signature
 PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
 
-PL_VERSION = PL_version(PL_VERSION_SYSTEM)
-if PL_VERSION<80200:
-    raise Exception("swi-prolog>= 8.2.0 is required")
+try:
+    PL_version = _lib.PL_version
+    PL_version.argtypes = [c_int]
+    PL_version.restype = c_uint
+
+    PL_VERSION = PL_version(PL_VERSION_SYSTEM)
+    if PL_VERSION<80200:
+        raise Exception("swi-prolog>= 8.2.0 is required")
+except AttributeError:
+    PL_VERSION=70000  # Best guess. When was PL_version introduced?
 
 
 # PySwip constants

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -703,6 +703,21 @@ BUF_MALLOC = 0x0200
 
 CVT_EXCEPTION = 0x10000  # throw exception on error
 
+
+
+#       /*******************************
+#        *	      VERSIONS		*
+#        *******************************/
+
+PL_VERSION_SYSTEM	=1	# Prolog version
+PL_VERSION_FLI		=2	# PL_* compatibility
+PL_VERSION_REC		=3	# PL_record_external() compatibility
+PL_VERSION_QLF		=4	# Saved QLF format version
+PL_VERSION_QLF_LOAD	=5	# Min loadable QLF format version
+PL_VERSION_VM		=6	# VM signature
+PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
+
+
 argv = list_to_bytes_list(sys.argv + [None])
 argc = len(sys.argv)
 
@@ -746,6 +761,15 @@ wint_t = c_uint
 PL_initialise = _lib.PL_initialise
 PL_initialise = check_strings(None, 1)(PL_initialise)
 #PL_initialise.argtypes = [c_int, c_c??
+
+#unsigned int PL_version(int key)
+PL_version = _lib.PL_version
+PL_version.argtypes = [c_int]
+PL_version.restype = c_uint
+
+PL_VERSION = PL_version(PL_VERSION_SYSTEM)
+if PL_VERSION<80200:
+    raise Exception("swi-prolog>= 8.2.0 is required")
 
 PL_open_foreign_frame = _lib.PL_open_foreign_frame
 PL_open_foreign_frame.restype = fid_t

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -580,45 +580,62 @@ c_double_p = c_void_p
 c_uint_p = c_void_p
 
 # constants (from SWI-Prolog.h)
-# PL_unify_term() arguments
-PL_VARIABLE = 1  # nothing
-PL_ATOM = 2  # const char
-PL_INTEGER = 3  # int
-PL_FLOAT = 4  # double
-PL_STRING = 5  # const char *
-PL_TERM = 6  #
-# PL_unify_term()
-PL_FUNCTOR = 10  # functor_t, arg ...
-PL_LIST = 11  # length, arg ...
-PL_CHARS = 12  # const char *
-PL_POINTER = 13  # void *
-#               /* PlArg::PlArg(text, type) */
-#define PL_CODE_LIST     (14)       /* [ascii...] */
-#define PL_CHAR_LIST     (15)       /* [h,e,l,l,o] */
-#define PL_BOOL      (16)       /* PL_set_feature() */
-#define PL_FUNCTOR_CHARS (17)       /* PL_unify_term() */
-#define _PL_PREDICATE_INDICATOR (18)    /* predicate_t (Procedure) */
-#define PL_SHORT     (19)       /* short */
-#define PL_INT       (20)       /* int */
-#define PL_LONG      (21)       /* long */
-#define PL_DOUBLE    (22)       /* double */
-#define PL_NCHARS    (23)       /* unsigned, const char * */
-#define PL_UTF8_CHARS    (24)       /* const char * */
-#define PL_UTF8_STRING   (25)       /* const char * */
-#define PL_INT64     (26)       /* int64_t */
-#define PL_NUTF8_CHARS   (27)       /* unsigned, const char * */
-#define PL_NUTF8_CODES   (29)       /* unsigned, const char * */
-#define PL_NUTF8_STRING  (30)       /* unsigned, const char * */
-#define PL_NWCHARS   (31)       /* unsigned, const wchar_t * */
-#define PL_NWCODES   (32)       /* unsigned, const wchar_t * */
-#define PL_NWSTRING  (33)       /* unsigned, const wchar_t * */
-#define PL_MBCHARS   (34)       /* const char * */
-#define PL_MBCODES   (35)       /* const char * */
-#define PL_MBSTRING  (36)       /* const char * */
+# /* PL_unify_term( arguments */
+PL_VARIABLE     = 1            # nothing
+PL_ATOM         = 2            # const char *
+PL_INTEGER      = 3            # int
+PL_RATIONAL     = 4            # rational number
+PL_FLOAT        = 5            # double
+PL_STRING       = 6            # const char *
+PL_TERM         = 7
 
-REP_ISO_LATIN_1 = 0x0000 # output representation
-REP_UTF8 = 0x1000
-REP_MB = 0x2000
+PL_NIL          = 8            # The constant []
+PL_BLOB         = 9            # non-atom blob
+PL_LIST_PAIR    = 10           # [_|_] term
+
+# # PL_unify_term(
+PL_FUNCTOR      = 11           # functor_t, arg ...
+PL_LIST         = 12           # length, arg ...
+PL_CHARS        = 13           # const char *
+PL_POINTER      = 14           # void *
+# PlArg::PlArg(text, type
+PL_CODE_LIST    = 15           # [ascii...]
+PL_CHAR_LIST    = 16           # [h,e,l,l,o]
+PL_BOOL         = 17           # PL_set_prolog_flag(
+PL_FUNCTOR_CHARS= 18           # PL_unify_term(
+_PL_PREDICATE_INDICATOR= 19    # predicate_t= Procedure
+PL_SHORT        = 20           # short
+PL_INT          = 21           # int
+PL_LONG         = 22           # long
+PL_DOUBLE       = 23           # double
+PL_NCHARS       = 24           # size_t, const char *
+PL_UTF8_CHARS   = 25           # const char *
+PL_UTF8_STRING  = 26           # const char *
+PL_INT64        = 27           # int64_t
+PL_NUTF8_CHARS  = 28           # size_t, const char *
+PL_NUTF8_CODES  = 29           # size_t, const char *
+PL_NUTF8_STRING = 30           # size_t, const char *
+PL_NWCHARS      = 31           # size_t, const wchar_t *
+PL_NWCODES      = 32           # size_t, const wchar_t *
+PL_NWSTRING     = 33           # size_t, const wchar_t *
+PL_MBCHARS      = 34           # const char *
+PL_MBCODES      = 35           # const char *
+PL_MBSTRING     = 36           # const char *
+PL_INTPTR       = 37           # intptr_t
+PL_CHAR         = 38           # int
+PL_CODE         = 39           # int
+PL_BYTE         = 40           # int
+# PL_skip_list(
+PL_PARTIAL_LIST = 41           # a partial list
+PL_CYCLIC_TERM  = 42           # a cyclic list/term
+PL_NOT_A_LIST   = 43           # Object is not a list
+# dicts
+PL_DICT         = 44
+
+
+REP_ISO_LATIN_1 = 0x0000  # output representation
+REP_UTF8 = 0x00100000
+REP_MB = 0x00200000
 
 #       /********************************
 #       * NON-DETERMINISTIC CALL/RETURN *

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with io.open("README.md", encoding="utf-8") as f:
 
 
 setup(name="pyswip",
-      version="0.2.9",
+      version="0.3.0",
       url="https://github.com/yuce/pyswip",
       download_url="https://github.com/yuce/pyswip/releases",
       author="Yuce Tekol",

--- a/tests/test_prolog.py
+++ b/tests/test_prolog.py
@@ -80,6 +80,16 @@ class TestProlog(unittest.TestCase):
         p.assertz('some_string_fact("abc")')
         self.assertEqual([{"S": b"abc"}], list(p.query("some_string_fact(S)")))
 
+    def test_quoted_strings(self):
+        """
+        See: https://github.com/yuce/pyswip/issues/90
+        """
+        p = pl.Prolog()
+        self.assertEqual([{"X": b"a"}], list(p.query('X = "a"')))
+
+        p.assertz('test_quoted_strings("hello","world")')
+        self.assertEqual([{"A": b"hello", "B": b"world"}], list(p.query('test_quoted_strings(A,B)')))
+
     def test_prolog_read_file(self):
         """
         See: https://github.com/yuce/pyswip/issues/10


### PR DESCRIPTION
PL_STRING has changed in SWI-Prolog.h.

   * Synchronized type constants with SWI-Prolog.h
    update for broken compatibility changes in SWI-Prolog.h.
    Update to swi-prolog >= 0.8.2 is required (and the default apt
    for Ubuntu >= 14.04).
  * Fix incorrect REP_* constants.  
  * Fixed https://github.com/yuce/pyswip/issues/92 (C assert)
  * Fixed https://github.com/yuce/pyswip/issues/90 (quoted string)
