### PR TITLE
use LIBSWIPL_PATH from environment

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -402,8 +402,11 @@ def _findSwipl():
     :rtype: Tuple of strings
     :raises ImportError: If we cannot guess the name of the library
     """
-
-    # Now begins the guesswork
+    # check environment
+    if 'LIBSWIPL_PATH' in os.environ:
+        return (os.environ['LIBSWIPL_PATH'], os.environ.get('SWI_HOME_DIR'))
+    
+    # Now begins the guesswork    
     platform = sys.platform[:3]
     if platform == "win": # In Windows, we have the default installer
                                    # path and the registry to look


### PR DESCRIPTION
On nixos the libswipl.so is not there, where pyswip could find it. 

Output of `swipl --dump-runtime-variables`:
```
PLBASE="/nix/store/jlik9111a3hmfs6q5bwd7fnkyzdh08yf-swi-prolog-8.1.15/lib/swipl";
PLARCH="x86_64-linux";
PLBITS="64";
PLVERSION="80115";
PLSOEXT="so";
PLSOPATH="LD_LIBRARY_PATH";
PLLIBDIR="/nix/store/jlik9111a3hmfs6q5bwd7fnkyzdh08yf-swi-prolog-8.1.15/lib/swipl/lib/x86_64-linux";
PLLIB="-lswipl";
PLSHARED="yes";
PLTHREADS="yes";
```
but the shared lib is here:
`/nix/store/jlik9111a3hmfs6q5bwd7fnkyzdh08yf-swi-prolog-8.1.15/lib/libswipl.so.8`

pyswip would expect it under $PLBASE/$PLARCH

swi-prolog on nixos is build with the flag -DSWIPL_INSTALL_IN_LIB=ON

one idea is to use a new environment variable, like in my patch. What do you think?