### PR TITLE
Backwards compability for Python 2 64bit

### DIFF
--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -23,7 +23,16 @@
 # SOFTWARE.
 
 
+import sys
+
 from pyswip.core import *
+
+
+# For backwards compability with Python 2 64bit
+if sys.version_info < (3,):
+    integer_types = (int, long,)
+else:
+    integer_types = (int,)
 
 
 class InvalidTypeError(TypeError):
@@ -67,7 +76,7 @@ class Atom(object):
 
         if isinstance(term, Term):
             term = term.handle
-        elif not isinstance(term, (c_void_p, int)):
+        elif not isinstance(term, (c_void_p, integer_types)):
             raise ArgumentTypeError((str(Term), str(c_void_p)), str(type(term)))
 
         a = atom_t()
@@ -266,7 +275,7 @@ class Functor(object):
 
         if isinstance(term, Term):
             term = term.handle
-        elif not isinstance(term, (c_void_p, int)):
+        elif not isinstance(term, (c_void_p, integer_types)):
             raise ArgumentTypeError((str(Term), str(int)), str(type(term)))
 
         f = functor_t()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -280,5 +280,5 @@ class TestExamples(unittest.TestCase):
 
 def example_path(path):
     import os.path
-    return os.path.normpath(os.path.join(os.path.split(os.path.abspath(__file__))[0], "..", "examples", path))
+    return os.path.normpath(os.path.join(os.path.split(os.path.abspath(__file__))[0], "..", "examples", path)).replace("\\", "\\\\")
 


### PR DESCRIPTION
I discovered a problem when running pyswip on Python 2.7. I get the following error:

pyswip.easy.ArgumentTypeError: Expected an argument of type '("<class 'pyswip.easy.Term'>", "<type 'int'>")' but got '<type 'long'>

This problem is also discussed in https://github.com/yuce/pyswip/issues/40 but the proposed solution is not working, in my case.

I'm running Python 2.7 64bit in combination with SWI-Prolog 64 bit. The problem seems that the integers from the 64bit native library are represented as long in Python 2.7. This is not a problem in Python 3, as int and long are combined in one common datatype.

The workaround for backwards compatibility is adapted from http://python3porting.com/differences.html
I tested the code with 64bit SWI Prolog 8.2.1 on both Python 2.7.16 (64bit) and Python 3.8.3 (64bit).