### PR TITLE
Improved handling of lists, nested lists, strings, and atoms

### DIFF
--- a/pyswip/__init__.py
+++ b/pyswip/__init__.py
@@ -26,5 +26,5 @@
 # PySwip version
 __VERSION__ = "0.2.11"
 
-from pyswip.easy import *
 from pyswip.prolog import Prolog
+from pyswip.easy import *

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -1055,9 +1055,17 @@ PL_unify_list = _lib.PL_unify_list
 PL_unify_list.argtypes = [term_t, term_t, term_t]
 PL_unify_list.restype = c_int
 
+PL_unify_atom = _lib.PL_unify_atom
+PL_unify_atom.argtypes = [term_t, atom_t]
+PL_unify_atom.restype = c_int
+
 PL_unify_atom_chars = _lib.PL_unify_atom_chars
 PL_unify_atom_chars.argtypes = [term_t, c_char_p]
 PL_unify_atom_chars.restype = c_int
+
+PL_unify_string_chars = _lib.PL_unify_string_chars
+PL_unify_string_chars.argtypes = [term_t, c_char_p]
+PL_unify_string_chars.restype = c_void_p
 
 PL_foreign_control = _lib.PL_foreign_control
 PL_foreign_control.argtypes = [control_t]

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -1207,8 +1207,8 @@ PL_exception = _lib.PL_exception
 PL_exception.argtypes = [qid_t]
 PL_exception.restype = term_t
 #
-PL_register_foreign = _lib.PL_register_foreign
-PL_register_foreign = check_strings(0, None)(PL_register_foreign)
+PL_register_foreign_in_module = _lib.PL_register_foreign_in_module
+PL_register_foreign_in_module = check_strings(0, None)(PL_register_foreign_in_module)
 
 #
 #PL_EXPORT(atom_t)      PL_new_atom(const char *s);

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -1055,6 +1055,10 @@ PL_unify_list = _lib.PL_unify_list
 PL_unify_list.argtypes = [term_t, term_t, term_t]
 PL_unify_list.restype = c_int
 
+PL_unify_nil = _lib.PL_unify_nil
+PL_unify_nil.argtypes = [term_t]
+PL_unify_nil.restype = c_int
+
 PL_unify_atom = _lib.PL_unify_atom
 PL_unify_atom.argtypes = [term_t, atom_t]
 PL_unify_atom.restype = c_int

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -173,8 +173,11 @@ class Variable(object):
             self.chars = self.chars.decode()
 
     def unify(self, value):
-        if isstr(value):
-            fun = PL_unify_atom_chars
+        if type(value) == Atom:
+            fun = PL_unify_atom
+            value = value.handle
+        elif isstr(value):
+            fun = PL_unify_string_chars
             value = value.encode()
         elif type(value) == int:
             fun = PL_unify_integer

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -202,9 +202,13 @@ class Variable(object):
 
         if type(value) == list:
             a = PL_new_term_ref(self.handle)
+            list_term = t
             for element in value:
-                fun(t, a, t)
+                tail_term = PL_new_term_ref(self.handle)
+                fun(list_term, a, tail_term)
                 self._fun(element, a)
+                list_term = tail_term
+            PL_unify_nil(list_term)
         else:
             fun(t, value)
 

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -173,6 +173,15 @@ class Variable(object):
             self.chars = self.chars.decode()
 
     def unify(self, value):
+        if self.handle is None:
+            t = PL_new_term_ref(self.handle)
+        else:
+            t = PL_copy_term_ref(self.handle)
+
+        self._fun(value, t)
+        self.handle = t
+
+    def _fun(self, value, t):
         if type(value) == Atom:
             fun = PL_unify_atom
             value = value.handle
@@ -191,26 +200,13 @@ class Variable(object):
             raise TypeError('Cannot unify {} with value {} due to the value unknown type {}'.
                             format(self, value, type(value)))
 
-        if self.handle is None:
-            t = PL_new_term_ref(self.handle)
-        else:
-            t = PL_copy_term_ref(self.handle)
-
         if type(value) == list:
             a = PL_new_term_ref(self.handle)
-            if type(value[0]) == int:
-                element_fun = PL_unify_integer
-            elif type(value[0]) == float:
-                element_fun = PL_unify_float
-            else:
-                raise
-            if value:
-                for element in value:
-                    fun(t, a, t)
-                    element_fun(a, element)
+            for element in value:
+                fun(t, a, t)
+                self._fun(a, element)
         else:
             fun(t, value)
-        self.handle = t
 
     def get_value(self):
         return getTerm(self.handle)

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -23,7 +23,16 @@
 # SOFTWARE.
 
 
+import sys
+
 from pyswip.core import *
+
+
+# For backwards compability with Python 2 64bit
+if sys.version_info < (3,):
+    integer_types = (int, long,)
+else:
+    integer_types = (int,)
 
 
 class InvalidTypeError(TypeError):
@@ -67,7 +76,7 @@ class Atom(object):
 
         if isinstance(term, Term):
             term = term.handle
-        elif not isinstance(term, (c_void_p, int)):
+        elif not isinstance(term, (c_void_p, integer_types)):
             raise ArgumentTypeError((str(Term), str(c_void_p)), str(type(term)))
 
         a = atom_t()
@@ -266,7 +275,7 @@ class Functor(object):
 
         if isinstance(term, Term):
             term = term.handle
-        elif not isinstance(term, (c_void_p, int)):
+        elif not isinstance(term, (c_void_p, integer_types)):
             raise ArgumentTypeError((str(Term), str(int)), str(type(term)))
 
         f = functor_t()

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -204,7 +204,7 @@ class Variable(object):
             a = PL_new_term_ref(self.handle)
             for element in value:
                 fun(t, a, t)
-                self._fun(a, element)
+                self._fun(element, a)
         else:
             fun(t, value)
 

--- a/pyswip/easy.py
+++ b/pyswip/easy.py
@@ -518,7 +518,7 @@ def _foreignWrapper(fun, nondeterministic=False):
 cwraps = []
 
 
-def registerForeign(func, name=None, arity=None, flags=0):
+def registerForeign(func, name=None, arity=None, flags=0, module=None):
     """Register a Python predicate
     ``func``: Function to be registered. The function should return a value in
     ``foreign_t``, ``True`` or ``False``.
@@ -541,7 +541,7 @@ def registerForeign(func, name=None, arity=None, flags=0):
     fwrap = _foreignWrapper(func, nondeterministic)
     fwrap2 = cwrap(fwrap)
     cwraps.append(fwrap2)
-    return PL_register_foreign(name, arity, fwrap2, flags)
+    return PL_register_foreign_in_module(module, name, arity, fwrap2, flags)
     # return PL_register_foreign(name, arity,
     #            _callbackWrapper(arity)(_foreignWrapper(func)), flags)
 

--- a/pyswip/prolog.py
+++ b/pyswip/prolog.py
@@ -191,7 +191,7 @@ def normalize_values(values):
     if isinstance(values, Atom):
         return values.value
     if isinstance(values, Functor):
-        normalized = values.name.value
+        normalized = str(values.name.value)
         if values.arity:
             normalized_args = ([str(normalize_values(arg)) for arg in values.args])
             normalized = normalized + '(' + ', '.join(normalized_args) + ')'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -285,7 +285,7 @@ class TestExamples(unittest.TestCase):
         num_facts = 1250000
         prolog = Prolog()
         for i in range(num_facts):
-            prolog.assertz(f'p({i})')
+            prolog.assertz('p(%s)' % i)
 
         results = [r for r in prolog.query('p(I)')]
         self.assertEqual(len(results), num_facts)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -280,5 +280,5 @@ class TestExamples(unittest.TestCase):
 
 def example_path(path):
     import os.path
-    return os.path.normpath(os.path.join(os.path.split(os.path.abspath(__file__))[0], "..", "examples", path))
+    return os.path.normpath(os.path.join(os.path.split(os.path.abspath(__file__))[0], "..", "examples", path)).replace("\\", "\\\\")
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -46,6 +46,37 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(len(result), 10, 'Query should return 10 results')
         for i in range(10):
             self.assertTrue({'X': i} in result, 'Expected result  X:{} not present'.format(i))
+    
+    def test_atoms_and_strings_distinction(self):
+        def get_str(string):
+            string.value = "string"
+        
+        def test_for_string(string, result):
+            result.value = isinstance(string, str) 
+
+        get_str.arity = 1
+        test_for_string.arity = 2
+
+        registerForeign(get_str)
+        registerForeign(test_for_string)
+
+        prolog = Prolog()
+        
+        result = list(prolog.query("get_str(String), test_for_string(String, Result)"))
+        self.assertTrue({'Result': 'true', 'String': 'string'} in result, 'A string return value should not be converted to an atom.')
+    
+    def test_nested_lists(self):
+        def get_list_of_lists(result):
+            result.value = [[1], [2]]
+
+        get_list_of_lists.arity = 1
+
+        registerForeign(get_list_of_lists)
+
+        prolog = Prolog()
+        
+        result = list(prolog.query("get_list_of_lists(Result)"))
+        self.assertTrue({'Result': [[1], [2]]} in result, 'A string return value should not be converted to an atom.')
 
 
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -76,7 +76,7 @@ class MyTestCase(unittest.TestCase):
         prolog = Prolog()
         
         result = list(prolog.query("get_list_of_lists(Result)"))
-        self.assertTrue({'Result': [[1], [2]]} in result, 'A string return value should not be converted to an atom.')
+        self.assertTrue({'Result': [[1], [2]]} in result, 'Nested lists should be unified correctly as return value.')
     
     def test_register_with_module(self):
         def get_int(result):

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -77,6 +77,19 @@ class MyTestCase(unittest.TestCase):
         
         result = list(prolog.query("get_list_of_lists(Result)"))
         self.assertTrue({'Result': [[1], [2]]} in result, 'A string return value should not be converted to an atom.')
+    
+    def test_register_with_module(self):
+        def get_int(result):
+            result.value = 1
+
+        get_int.arity = 1
+
+        registerForeign(get_int, module="my_module")
+
+        prolog = Prolog()
+        
+        result = list(prolog.query("my_module:get_int(Result)"))
+        self.assertTrue({'Result': 1} in result, 'One should be able to call the foreign predicate by using the module name.')
 
 
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyswip import Prolog, registerForeign, PL_foreign_context, PL_foreign_control, PL_FIRST_CALL, PL_REDO, PL_PRUNED, PL_retry, PL_FA_NONDETERMINISTIC
+from pyswip import Prolog, registerForeign, PL_foreign_context, PL_foreign_control, PL_FIRST_CALL, PL_REDO, PL_PRUNED, PL_retry, PL_FA_NONDETERMINISTIC, Variable
 
 
 class MyTestCase(unittest.TestCase):
@@ -65,6 +65,11 @@ class MyTestCase(unittest.TestCase):
         result = list(prolog.query("get_str(String), test_for_string(String, Result)"))
         self.assertTrue({'Result': 'true', 'String': 'string'} in result, 'A string return value should not be converted to an atom.')
     
+    def test_unifying_list_correctly(self):
+        variable = Variable()
+        variable.value = [1, 2]
+        self.assertEquals(variable.value, [1, 2], 'Lists should be unifyed correctly.')
+
     def test_nested_lists(self):
         def get_list_of_lists(result):
             result.value = [[1], [2]]


### PR DESCRIPTION
I created additional support for strings and nested lists in pyswip foreign predicates.

- pyswip foreign predicates now distinguishes between strings and atoms when unifying.
- pyswip foreign predicates can now unify lists of lists (recursive).
- Lists are now unified in a way such that the list can be correctly accessed using the getter method of pyswip.Variable
- It is now possible to register a foreign predicate in a specific module.

I also added tests under test_foreign.py. The tests run successfully with SWI Prolog 8.2.1 and Python 2.7.16 (31bit)