### PR TITLE
Support SWI-Prolog versions > 8.5.2

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,3 +26,4 @@ Guglielmo Gemignani
 Vince Jankovics
 Tobias Grubenmann
 Arvid Norlander
+David Cox

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -589,24 +589,18 @@ PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
 # https://github.com/SWI-Prolog/swipl-devel/issues/900
 # https://github.com/SWI-Prolog/swipl-devel/issues/910
 try:
-    # swi-prolog > 8.5.2:
-    PL_version_info = _lib.PL_version_info
-    PL_version_info.argtypes = [c_int]
-    PL_version_info.restype = c_uint
+    if _lib.PL_version_info != None:
+        PL_version = _lib.PL_version_info # swi-prolog > 8.5.2
+    else:
+        PL_version = _lib.PL_version # swi-prolog <= 8.5.2
+    PL_version.argtypes = [c_int]
+    PL_version.restype = c_uint
 
-    PL_VERSION = PL_version_info(PL_VERSION_SYSTEM)
+    PL_VERSION = PL_version(PL_VERSION_SYSTEM)
+    if PL_VERSION<80200:
+        raise Exception("swi-prolog>= 8.2.0 is required")
 except AttributeError:
-    # swi-prolog <= 8.5.2:
-    try:
-        PL_version = _lib.PL_version
-        PL_version.argtypes = [c_int]
-        PL_version.restype = c_uint
-
-        PL_VERSION = PL_version(PL_VERSION_SYSTEM)
-        if PL_VERSION<80200:
-            raise Exception("swi-prolog>= 8.2.0 is required")
-    except AttributeError:
-        raise Exception("swi-prolog version number could not be determined")
+    raise Exception("swi-prolog version number could not be determined")
 
 
 # PySwip constants

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -598,7 +598,7 @@ try:
 
     PL_VERSION = PL_version(PL_VERSION_SYSTEM)
     if PL_VERSION<80200:
-        raise Exception("swi-prolog>= 8.2.0 is required")
+        raise Exception("swi-prolog >= 8.2.0 is required")
 except AttributeError:
     raise Exception("swi-prolog version number could not be determined")
 

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -583,16 +583,30 @@ PL_VERSION_QLF_LOAD	=5	# Min loadable QLF format version
 PL_VERSION_VM		=6	# VM signature
 PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
 
-try:
-    PL_version = _lib.PL_version
-    PL_version.argtypes = [c_int]
-    PL_version.restype = c_uint
 
-    PL_VERSION = PL_version(PL_VERSION_SYSTEM)
-    if PL_VERSION<80200:
-        raise Exception("swi-prolog>= 8.2.0 is required")
+# After SWI-Prolog 8.5.2, PL_version was renamed to PL_version_info
+# to avoid a conflict with Perl. For more details, see the following:
+# https://github.com/SWI-Prolog/swipl-devel/issues/900
+# https://github.com/SWI-Prolog/swipl-devel/issues/910
+try:
+    # swi-prolog > 8.5.2:
+    PL_version_info = _lib.PL_version_info
+    PL_version_info.argtypes = [c_int]
+    PL_version_info.restype = c_uint
+
+    PL_VERSION = PL_version_info(PL_VERSION_SYSTEM)
 except AttributeError:
-    PL_VERSION=70000  # Best guess. When was PL_version introduced?
+    # swi-prolog <= 8.5.2:
+    try:
+        PL_version = _lib.PL_version
+        PL_version.argtypes = [c_int]
+        PL_version.restype = c_uint
+
+        PL_VERSION = PL_version(PL_VERSION_SYSTEM)
+        if PL_VERSION<80200:
+            raise Exception("swi-prolog>= 8.2.0 is required")
+    except AttributeError:
+        raise Exception("swi-prolog version number could not be determined")
 
 
 # PySwip constants


### PR DESCRIPTION
`PL_version` was renamed to `PL_version_info` in SWI-Prolog due to [Exported symbol PL_version conflicts with symbol in Perl](https://github.com/SWI-Prolog/swipl-devel/issues/900).

I noticed that this change resulted in a crash in PySwip, and opened [swipl-devel #910](https://github.com/SWI-Prolog/swipl-devel/issues/910). 

After reviewing the notes added to that issue by @dgelessus, I decided to open this PR with a fix.

> Jan recently had to rename SWI's PL_version function to PL_version_info, to avoid a name conflict with Perl - see #900 for the full context.
>
> It looks like PySwip tries to access the PL_version function, and if it can't find it, it assumes SWI-Prolog 7. With the recent renaming, PL_version doesn't exist anymore, so PySwip is misdetecting SWI-Prolog 8.5 as version 7. It then uses an older set of constant definitions, which are not compatible with the current SWI version, and this is probably causing the assertion failure.
>
> The way to fix this would be to extend your version check code to try calling PL_version_info first, and if that function doesn't exist, fall back to PL_version.
>
> Perhaps it would also be a good idea to throw an error if neither PL_version_info nor PL_version can be found? It looks like PySwip requires at least SWI-Prolog 8.2.0 anyway - so if the SWI-Prolog library doesn't define any of the version symbols, it's either too old to work with PySwip, or the library is broken in some way.