### PR TITLE
Removing trailing whitespaces

### DIFF
--- a/examples/coins/coins.py
+++ b/examples/coins/coins.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -44,6 +44,6 @@ def main():
         print()
     list(prolog.query("coins(S, %d, %d)." % (count,total)))
 
-    
+
 if __name__ == "__main__":
     main()

--- a/examples/coins/coins_new.py
+++ b/examples/coins/coins_new.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -52,6 +52,6 @@ def main():
         i += 1
     q.closeQuery()
 
-    
+
 if __name__ == "__main__":
     main()

--- a/examples/create_term.py
+++ b/examples/create_term.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,7 +26,7 @@ from pyswip.prolog import Prolog
 
 def main():
     prolog = Prolog()
-    
+
     a1 = PL_new_term_refs(2)
     a2 = a1 + 1
     t = PL_new_term_ref()
@@ -40,9 +40,9 @@ def main():
     PL_cons_functor_v(t, animal2, a1)
     PL_cons_functor_v(ta, assertz, t)
     PL_call(ta, None)
-    
+
     print(list(prolog.query("animal(X,Y)", catcherrors=True)))
 
-    
+
 if __name__ == "__main__":
     main()

--- a/examples/draughts/puzzle1.py
+++ b/examples/draughts/puzzle1.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -55,11 +55,11 @@ def main():
         # [NW,N,NE,W,E,SW,S,SE]
         print("%d %d %d" % tuple(B[:3]))
         print("%d   %d"   % tuple(B[3:5]))
-        print("%d %d %d" % tuple(B[5:]))        
+        print("%d %d %d" % tuple(B[5:]))
 
         cont = input("Press 'n' to finish: ")
         if cont.lower() == "n": break
 
-        
+
 if __name__ == "__main__":
     main()

--- a/examples/father.py
+++ b/examples/father.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/examples/hanoi/hanoi.py
+++ b/examples/hanoi/hanoi.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,12 +36,12 @@ except NameError:
 class Notifier:
     def __init__(self, fun):
         self.fun = fun
-        
+
     def notify(self, t):
         return not self.fun(t)
     notify.arity = 1
 
-    
+
 class Tower:
     def __init__(self, N=3, interactive=False):
         """N is the number of disks
@@ -51,7 +51,7 @@ class Tower:
         self.started = False
         self.interactive = interactive
         self.step = 0
-        
+
     def move(self, r):
         if not self.started:
             self.step += 1
@@ -62,7 +62,7 @@ class Tower:
         disks[str(r[1])].append(disks[str(r[0])].pop())
         self.step += 1
         return self.draw()
-        
+
     def draw(self):
         disks = self.disks
         print("\n Step", self.step)
@@ -85,7 +85,7 @@ class Tower:
 def main():
     N = 3
     INTERACTIVITY = True
-    
+
     prolog = Prolog()
     tower = Tower(N, INTERACTIVITY)
     notifier = Notifier(tower.move)
@@ -93,6 +93,6 @@ def main():
     prolog.consult("hanoi.pl")
     list(prolog.query("hanoi(%d)" % N))
 
-    
+
 if __name__ == "__main__":
     main()

--- a/examples/hanoi/hanoi_simple.py
+++ b/examples/hanoi/hanoi_simple.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,12 +31,12 @@ def main():
     def notify(t):
         print("move disk from %s pole to %s pole." % tuple(t))
     notify.arity = 1
-        
+
     prolog = Prolog()
     registerForeign(notify)
     prolog.consult("hanoi.pl")
     list(prolog.query("hanoi(%d)" % N))
 
-    
+
 if __name__ == "__main__":
     main()

--- a/examples/knowledgebase.py
+++ b/examples/knowledgebase.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/examples/register_foreign.py
+++ b/examples/register_foreign.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/examples/register_foreign_simple.py
+++ b/examples/register_foreign_simple.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,9 +37,9 @@ def main():
     registerForeign(hello)
     prolog = Prolog()
     prolog.assertz("father(michael,john)")
-    prolog.assertz("father(michael,gina)")    
+    prolog.assertz("father(michael,gina)")
     list(prolog.query("father(michael,X), hello(X)"))
 
-    
+
 if __name__ =="__main__":
     main()

--- a/examples/sendmoremoney/money.py
+++ b/examples/sendmoremoney/money.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/examples/sendmoremoney/money_new.py
+++ b/examples/sendmoremoney/money_new.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,7 +38,7 @@ def main():
     prolog = Prolog()
     sendmore = Functor("sendmore")
     prolog.consult("money.pl")
-    
+
     X = Variable()
     call(sendmore(X))
     r = X.value

--- a/examples/sudoku/sudoku.py
+++ b/examples/sudoku/sudoku.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -59,7 +59,7 @@ def pretty_print(table):
         print("".join(["|", "|".join(" %s " % (i or " ") for i in row), "|"]))
     print("".join(["\\---", "----"*8, "/"]))
 
-    
+
 def solve(problem):
     prolog.consult("sudoku.pl")
     p = str(problem).replace("0", "_")
@@ -70,7 +70,7 @@ def solve(problem):
     else:
         return False
 
-    
+
 def main():
     puzzle = puzzle1
     print("-- PUZZLE --")
@@ -83,7 +83,7 @@ def main():
     else:
         print("This puzzle has no solutions [is it valid?]")
 
-        
+
 if __name__ == "__main__":
     prolog = Prolog()
     main()

--- a/examples/sudoku/sudoku_daily.py
+++ b/examples/sudoku/sudoku_daily.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,7 +45,7 @@ class DailySudokuPuzzle(HTMLParser):
         self.puzzle = []
         self.__in_td = False
         HTMLParser.__init__(self)
-        
+
     def handle_starttag(self, tag, attrs):
         if tag == "td":
             for attr in attrs:
@@ -55,23 +55,23 @@ class DailySudokuPuzzle(HTMLParser):
         elif tag == "input":
             if self.__in_td:
                 self.puzzle.append(0)
-                
+
     def handle_endtag(self, tag):
         if tag == "td":
             self.__in_td = False
-            
+
     def handle_data(self, data):
         if self.__in_td:
             self.puzzle.append(int(data))
 
-            
+
 def pretty_print(table):
     print("".join(["/---", "----"*8, "\\"]))
     for row in table:
         print("".join(["|", "|".join(" %s " % (i or " ") for i in row), "|"]))
     print("".join(["\\---", "----"*8, "/"]))
 
-    
+
 def get_daily_sudoku(url):
     puzzle = DailySudokuPuzzle()
     f = urllib_request.urlopen(url)
@@ -88,14 +88,14 @@ def solve(problem):
         result = result[0]
         return result["Puzzle"]
     else:
-        return False    
+        return False
 
 
 if __name__ == "__main__":
     URL = "http://www.sudoku.org.uk/daily.asp"
 
     prolog = Prolog()  # having this in `solve` bites! because of __del__
-    print("Getting puzzle from:", URL)    
+    print("Getting puzzle from:", URL)
     puzzle = get_daily_sudoku(URL)
     print("-- PUZZLE --")
     pretty_print(puzzle)

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -275,11 +275,11 @@ def walk(path, name):
     """
     This function is a 2-time recursive func,
     that findin file in dirs
-    
+
     :parameters:
       -  `path` (str) - Directory path
       -  `name` (str) - Name of file, that we lookin for
-      
+
     :returns:
         Path to the swipl so, path to the resource file
 
@@ -288,7 +288,7 @@ def walk(path, name):
     """
     back_path = path[:]
     path = os.path.join(path, name)
-    
+
     if os.path.exists(path):
         return path
     else:
@@ -310,7 +310,7 @@ def get_swi_ver():
     match = re.search(r'[0-9]+\.[0-9]+\.[0-9]+', swi_ver)
     if match is None:
         raise InputError('Error, type normal version')
-    
+
     return swi_ver
 
 
@@ -318,10 +318,10 @@ def _findSwiplMacOSHome():
     """
     This function is guesing where SWI-Prolog is
     installed in MacOS via .app.
-    
+
     :parameters:
       -  `swi_ver` (str) - Version of SWI-Prolog in '[0-9].[0-9].[0-9]' format
-      
+
     :returns:
         A tuple of (path to the swipl so, path to the resource file)
 
@@ -332,15 +332,15 @@ def _findSwiplMacOSHome():
     # Need more help with MacOS
     # That way works, but need more work
     names = ['libswipl.dylib', 'libpl.dylib']
-    
+
     path = os.environ.get('SWI_HOME_DIR')
     if path is None:
         path = os.environ.get('SWI_LIB_DIR')
         if path is None:
             path = os.environ.get('PLBASE')
-            if path is None:                
+            if path is None:
                 path = '/Applications/SWI-Prolog.app/Contents/'
-    
+
     paths = [path]
 
     for name in names:
@@ -414,7 +414,7 @@ def _findSwipl():
 
     elif platform == "dar":  # Help with MacOS is welcome!!
         (path, swiHome) = _findSwiplDar()
-        
+
         if path is None:
             (path, swiHome) = _findSwiplMacOSHome()
 

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2020 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,17 +2,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,30 +37,30 @@ class TestExamples(unittest.TestCase):
 
     WARNING: Since it is not possible to unload things from the Prolog base, the
     examples have to be 'orthogonal'.
-    
+
     """
 
     def test_create_term(self):
         """
         Simple example of term creation.
         """
-        
+
         prolog = Prolog()
-    
+
         a1 = PL_new_term_refs(2)
         a2 = a1 + 1
         t = PL_new_term_ref()
         ta = PL_new_term_ref()
- 
+
         animal2 = PL_new_functor(PL_new_atom("animal"), 2)
         assertz = PL_new_functor(PL_new_atom("assertz"), 1)
- 
+
         PL_put_atom_chars(a1, "gnu")
         PL_put_integer(a2, 50)
         PL_cons_functor_v(t, animal2, a1)
         PL_cons_functor_v(ta, assertz, t)
         PL_call(ta, None)
-    
+
         result = list(prolog.query("animal(X,Y)", catcherrors=True))
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], {'X': 'gnu', 'Y': 50})
@@ -71,20 +71,20 @@ class TestExamples(unittest.TestCase):
         """
 
         p = Prolog()
-         
+
         assertz = Functor("assertz")
         parent = Functor("parent", 2)
         test1 = newModule("test1")
         test2 = newModule("test2")
-         
+
         call(assertz(parent("john", "bob")), module=test1)
         call(assertz(parent("jane", "bob")), module=test1)
-         
+
         call(assertz(parent("mike", "bob")), module=test2)
         call(assertz(parent("gina", "bob")), module=test2)
-         
+
         # Test knowledgebase module test1
- 
+
         result = set()
         X = Variable()
         q = Query(parent(X, "bob"), module=test1)
@@ -92,9 +92,9 @@ class TestExamples(unittest.TestCase):
             result.add(X.value.value)    # X.value is an Atom
         q.closeQuery()
         self.assertEqual(result, set(["john", "jane"]))
-         
+
         # Test knowledgebase module test2
-         
+
         result = set()
         q = Query(parent(X, "bob"), module=test2)
         while q.nextSolution():
@@ -108,18 +108,18 @@ class TestExamples(unittest.TestCase):
         """
 
         p = Prolog()
-     
+
         father = Functor("father", 2)
         mother = Functor("mother", 2)
-     
+
         p.assertz("father(john,mich)")
         p.assertz("father(john,gina)")
         p.assertz("mother(jane,mich)")
-     
+
         X = Variable()
         Y = Variable()
         Z = Variable()
-  
+
         result = []
         q = Query(father("john", Y), mother(Z, Y))
         while q.nextSolution():
@@ -127,7 +127,7 @@ class TestExamples(unittest.TestCase):
             z = Z.value.value
             result.append({'Y': y, 'Z': z})
         q.closeQuery()
-   
+
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], {'Y': 'mich', 'Z': 'jane'})
 
@@ -137,7 +137,7 @@ class TestExamples(unittest.TestCase):
             result.append(s)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], {'Y': 'mich', 'Z': 'jane'})
-     
+
     def test_coins(self):
         """
         Runs the coins example (uses clp library of SWI-Prolog).
@@ -150,12 +150,12 @@ class TestExamples(unittest.TestCase):
         coins = Functor("coins", 3)
         S = Variable()
         q = Query(coins(S, count, total))
- 
+
         solutions = []
         while q.nextSolution():
             solutions.append(S.value)
         q.closeQuery()
- 
+
         self.assertEqual(len(solutions), 105)
 
         # Now do the same test, but using the prolog.query interface
@@ -166,7 +166,7 @@ class TestExamples(unittest.TestCase):
         """
         Runs the draughts example (uses clp library of SWI-Prolog).
         """
-        
+
         prolog = Prolog()
         prolog.consult(example_path("draughts/puzzle1.pl"))
         solutions = []
@@ -177,29 +177,29 @@ class TestExamples(unittest.TestCase):
         # Now do the same test, but using the prolog.query interface
         solutions = list(prolog.query("solve(B)."))
         self.assertEqual(len(solutions), 37)
-        
+
     def test_hanoi(self):
         """
         Runs the hanoi example.
         """
- 
+
         N = 3  # Number of disks
- 
+
         result = []
         def notify(t):
             result.append((t[0].value, t[1].value))
         notify.arity = 1
- 
+
         prolog = Prolog()
         registerForeign(notify)
         prolog.consult(example_path("hanoi/hanoi.pl"))
         list(prolog.query("hanoi(%d)" % N)) # Forces the query to run completely
- 
+
         self.assertEqual(len(result), 7)
         self.assertEqual(result[0], ('left', 'right'))
         self.assertEqual(result[1], ('left', 'center'))
         self.assertEqual(result[2], ('right', 'center'))
-        
+
     def test_sendmoremoney(self):
         """
         Runs the sendmoremoney example::
@@ -208,11 +208,11 @@ class TestExamples(unittest.TestCase):
             M O R E
           + -------
           M O N E Y
-         
+
         So, what should be the values of S, E, N, D, M, O, R, Y
         if they are all distinct digits.
         """
-        
+
         letters = "S E N D M O R Y".split()
         prolog = Prolog()
         sendmore = Functor("sendmore")
@@ -226,17 +226,17 @@ class TestExamples(unittest.TestCase):
             val[letter] = r[i]
 
         self.assertEqual(len(val), 8)
-        
+
         send = val['S']*1e3 + val['E']*1e2 + val['N']*1e1 + val['D']*1e0
         more = val['M']*1e3 + val['O']*1e2 + val['R']*1e1 + val['E']*1e0
         money = val['M']*1e4 + val['O']*1e3 + val['N']*1e2 + val['E']*1e1 + val['Y']*1e0
         self.assertEqual(money, send + more)
- 
+
     def test_sudoku(self):
         """
         Runs the sudoku example (uses clp library of SWI-Prolog).
         """
-        
+
         _ = 0
         puzzle1 = [
             [_,6,_,1,_,4,_,5,_],
@@ -249,7 +249,7 @@ class TestExamples(unittest.TestCase):
             [_,_,7,2,_,6,9,_,_],
             [_,4,_,5,_,8,_,7,_]
             ]
-         
+
         puzzle2 = [
             [_,_,1,_,8,_,6,_,4],
             [_,3,7,6,_,_,_,_,_],
@@ -261,7 +261,7 @@ class TestExamples(unittest.TestCase):
             [_,_,_,_,_,7,5,2,_],
             [8,_,2,_,9,_,7,_,_]
                   ]
-            
+
         prolog = Prolog()
         prolog.consult(example_path("sudoku/sudoku.pl"))
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -46,13 +46,13 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(len(result), 10, 'Query should return 10 results')
         for i in range(10):
             self.assertTrue({'X': i} in result, 'Expected result  X:{} not present'.format(i))
-    
+
     def test_atoms_and_strings_distinction(self):
         test_string = "string"
 
         def get_str(string):
             string.value = test_string
-        
+
         def test_for_string(string, test_result):
             test_result.value = (test_string == string.decode('utf-8'))
 
@@ -63,10 +63,10 @@ class MyTestCase(unittest.TestCase):
         registerForeign(test_for_string)
 
         prolog = Prolog()
-        
+
         result = list(prolog.query("get_str(String), test_for_string(String, Result)"))
         self.assertEqual(result[0]['Result'], 'true', 'A string return value should not be converted to an atom.')
-    
+
     def test_unifying_list_correctly(self):
         variable = Variable()
         variable.value = [1, 2]
@@ -81,7 +81,7 @@ class MyTestCase(unittest.TestCase):
         registerForeign(get_list_of_lists)
 
         prolog = Prolog()
-        
+
         result = list(prolog.query("get_list_of_lists(Result)"))
         self.assertTrue({'Result': [[1], [2]]} in result, 'Nested lists should be unified correctly as return value.')
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -3,17 +3,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2012 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -61,7 +61,7 @@ class TestIssues(unittest.TestCase):
 
         Notes: This issue manifests only in 64bit stacks (note that a full 64
         bit stack is needed. If running 32 in 64bit, it will not happen.)
-        
+
         http://code.google.com/p/pyswip/issues/detail?id=1
         """
 
@@ -92,7 +92,7 @@ class TestIssues(unittest.TestCase):
         prolog.assertz("parent(michael,gina)")
         p = prolog.query("parent(michael,X), hello(X)")
         result = list(p)   # Will run over the iterator
-        
+
         self.assertEqual(len(callsToHello), 2)  # ['john', 'gina']
         self.assertEqual(len(result), 2) # [{'X': 'john'}, {'X': 'gina'}]
 
@@ -147,7 +147,7 @@ class TestIssues(unittest.TestCase):
         A = Variable()
         B = Variable()
         C = Variable(A.handle)   # This is equal to A
-        
+
         self.assertNotEqual(A, B)
         self.assertNotEqual(C, B)
         self.assertEqual(A, C)
@@ -157,7 +157,7 @@ class TestIssues(unittest.TestCase):
         varSet.add(C)  # This is equal to A
         self.assertEqual(len(varSet), 2)
         self.assertEqual(varSet, set([A, B]))
-        
+
     def test_issue_4(self):
         """
        	Patch for a dynamic method
@@ -168,7 +168,7 @@ class TestIssues(unittest.TestCase):
         """
 
         from pyswip import Prolog
-        
+
         Prolog.dynamic('test_issue_4_d/1')
         Prolog.assertz('test_issue_4_d(test1)')
         Prolog.assertz('test_issue_4_d(test1)')
@@ -176,11 +176,11 @@ class TestIssues(unittest.TestCase):
         Prolog.assertz('test_issue_4_d(test2)')
         results = list(Prolog.query('test_issue_4_d(X)'))
         self.assertEqual(len(results), 4)
-        
+
         Prolog.retract('test_issue_4_d(test1)')
         results = list(Prolog.query('test_issue_4_d(X)'))
         self.assertEqual(len(results), 3)
-        
+
         Prolog.retractall('test_issue_4_d(test1)')
         results = list(Prolog.query('test_issue_4_d(X)'))
         self.assertEqual(len(results), 1)
@@ -193,14 +193,14 @@ class TestIssues(unittest.TestCase):
         """
 
         from pyswip import Prolog, Functor, Variable, Atom
-         
+
         p = Prolog()
-         
+
         f = Functor('f', 1)
         A = Variable()
         B = Variable()
         C = Variable()
-         
+
         x = f([A, B, C])
         x = Functor.fromTerm(x)
         args = x.args[0]
@@ -262,9 +262,9 @@ class TestIssues(unittest.TestCase):
         Not a formal issue, but see forum topic:
         https://groups.google.com/forum/#!topic/pyswip/Mpnfq4DH-mI
         """
-        
+
         import pyswip.prolog as pl
-        
+
         p = pl.Prolog()
         p.consult("tests/test_functor_return.pl", catcherrors=True)
         query = "sentence(Parse_tree, [the,bat,eats,a,cat], [])"
@@ -274,7 +274,7 @@ class TestIssues(unittest.TestCase):
         results = list(p.query(query))
         self.assertEqual(len(results), 1,
                          "Query should return exactly one result")
-        
+
         ptree = results[0]["Parse_tree"]
         self.assertEqual(ptree, expectedTree)
 
@@ -286,7 +286,7 @@ class TestIssues(unittest.TestCase):
         p.assertz("father(son(miki),kur)")
         p.assertz("father(son(kiwi),kur)")
         p.assertz("father(son(wiki),kur)")
-        
+
         soln = [s["Y"] for s in p.query("friend(john,Y), father(Y,kur)",
                                          maxresult=1)]
         self.assertEqual(soln[0], "son(miki)")

--- a/tests/test_prolog.py
+++ b/tests/test_prolog.py
@@ -3,17 +3,17 @@
 
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2012 Yüce Tekol
-#  
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#  
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#  
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
As the title puts it, this patch removes trailing white spaces across the python code,
thus making it a bit cleaner and linters less agitated. 

Changes have no impact on the code function and are purely style oriented.

Signed-off-by: Jiri Podivin <jpodivin@gmail.com>