### PR TITLE
Find libswipl.so from `swipl --dump-runtime-variables`

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -102,8 +102,12 @@ def _findSwiplFromExec():
             if not os.path.exists(swiHome):
                 swiHome = None
 
+            # determine platform specific path.  First try runtime
+            # variable `PLLIBSWIPL` introduced in 9.1.1/9.0.1
+            if 'PLLIBSWIPL' in rtvars:
+                fullName = rtvars['PLLIBSWIPL']
             # determine platform specific path
-            if platform == "win":
+            elif platform == "win":
                 dllName = rtvars['PLLIB'][:-4] + '.' + rtvars['PLSOEXT']
                 path = os.path.join(rtvars['PLBASE'], 'bin')
                 fullName = os.path.join(path, dllName)


### PR DESCRIPTION
As of version 9.0.1/9.1.1, SWI-Prolog can tell where the shared object lives.  This works reliably on Windows, MacOS and Linux and any other system providing dladdr().   On other systems it uses the value derived from the CMake install configuration and may be wrong if the installation
is relocated.