### PR TITLE
Add abort functionality and handle exception in cleanup

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -1404,8 +1404,8 @@ def cleanupProlog():
         # If the program has come to an end the prolog system should not
         # interfere with that. Therefore we may want to use 1 instead of 0.
         try:
-            exit_code = _hook.exit_code
+            exit_code = int(_hook.exit_code or 0)
         except ValueError:
             exit_code = 0
-        PL_cleanup(int(exit_code or 0))
+        PL_cleanup(exit_code)
         _isCleaned = True

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -1403,5 +1403,9 @@ def cleanupProlog():
         # TODO Prolog documentation says cleanup with code 0 may be interrupted
         # If the program has come to an end the prolog system should not
         # interfere with that. Therefore we may want to use 1 instead of 0.
-        PL_cleanup(int(_hook.exit_code or 0))
+        try:
+            exit_code = _hook.exit_code
+        except ValueError:
+            exit_code = 0
+        PL_cleanup(int(exit_code or 0))
         _isCleaned = True


### PR DESCRIPTION
In this PR, I have added the method for aborting a query. Also, I have added the handling of an exception that popped up on our side during cleanup.