### PR TITLE
Fixed not finding swipl lib file when there are multiple options

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -28,3 +28,4 @@ Tobias Grubenmann
 Arvid Norlander
 David Cox
 Maximilian Peltzer
+Adi Harif

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -149,10 +149,8 @@ def _findSwiplFromExec():
                     files = glob.glob(pattern)
                     if len(files) == 0:
                         fullName = None
-                    elif len(files) == 1:
+                    else:
                         fullName = files[0]
-                    else:  # Will this ever happen?
-                        fullName = None
 
     except (OSError, KeyError): # KeyError from accessing rtvars
         pass


### PR DESCRIPTION
Before this patch it would not find libswipl.so because in my installation there were two libs:
1. libswipl.so.8.4.3
2. libswipl.so.8 (which is a symlink to the first)

Happened on Fedora 37 using python 3.11 and swipl 8.4.3