### PR TITLE
Avoid AttributeError with PL_version_info in swipl <= 8.4.2

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -28,3 +28,4 @@ Tobias Grubenmann
 Arvid Norlander
 David Cox
 Maximilian Peltzer
+Oisín Mac Fhearaí

--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -593,7 +593,7 @@ PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
 # https://github.com/SWI-Prolog/swipl-devel/issues/900
 # https://github.com/SWI-Prolog/swipl-devel/issues/910
 try:
-    if _lib.PL_version_info != None:
+    if hasattr(_lib, "PL_version_info"):
         PL_version = _lib.PL_version_info # swi-prolog > 8.5.2
     else:
         PL_version = _lib.PL_version # swi-prolog <= 8.5.2


### PR DESCRIPTION
In older versions of libswipl.so, pyswip produced this error:

```
Traceback (most recent call last):                                                                       
  File "/home/omf/.local/lib/python3.10/site-packages/pyswip/core.py", line 597, in <module>
    if _lib.PL_version_info != None:                                                                     
  File "/usr/lib/python3.10/ctypes/__init__.py", line 387, in __getattr__                                
    func = self.__getitem__(name)                                                                        
  File "/usr/lib/python3.10/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))                                                        
AttributeError: /lib/libswipl.so.8: undefined symbol: PL_version_info
```

This happened on my system with libswipl 8.4.2.
We can avoid this by using `hasattr` instead of comparing the property to None.