### PR TITLE
Fix compatibility with SWI-Prolog > 8.5.2

### DIFF
--- a/pyswip/core.py
+++ b/pyswip/core.py
@@ -594,10 +594,7 @@ PL_VERSION_BUILT_IN	=7	# Built-in predicate signature
 # https://github.com/SWI-Prolog/swipl-devel/issues/900
 # https://github.com/SWI-Prolog/swipl-devel/issues/910
 try:
-    if hasattr(_lib, "PL_version_info"):
-        PL_version = _lib.PL_version_info # swi-prolog > 8.5.2
-    else:
-        PL_version = _lib.PL_version # swi-prolog <= 8.5.2
+    PL_version = _lib.PL_version_info
     PL_version.argtypes = [c_int]
     PL_version.restype = c_uint
 


### PR DESCRIPTION
Fix: Ensure compatibility with SWI-Prolog > 8.5.2

- Updated `core.py` to use `PL_version_info` for all supported versions.
- Removed conditional checks for `PL_version` to simplify version handling.
- Ensured `PL_version.argtypes` and `PL_version.restype` are set correctly.

Tested successfully with SWI-Prolog version 9.3.7.