### PR TITLE
Prolog.consult method updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ prolog.consult("knowledge_base.pl")
 ### Foreign Functions
 
 ```python
-from __future__ import print_function
 from pyswip import Prolog, registerForeign
 
 def hello(t):
@@ -77,7 +76,6 @@ print(list(prolog.query("father(michael,X), hello(X)")))
 ### Pythonic interface (Experimental)
 
 ```python
-from __future__ import print_function
 from pyswip import Functor, Variable, Query, call
 
 assertz = Functor("assertz", 1)

--- a/examples/coins/coins.py
+++ b/examples/coins/coins.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
 #
@@ -23,27 +21,20 @@
 
 # 100 coins must sum to $5.00
 
-from __future__ import print_function
 from pyswip.prolog import Prolog
-
-try:
-    input = raw_input
-except NameError:
-    pass
-
 
 def main():
     prolog = Prolog()
-    prolog.consult("coins.pl")
+    prolog.consult("coins.pl", relative_to=__file__)
     count = int(input("How many coins (default: 100)? ") or 100)
     total = int(input("What should be the total (default: 500)? ") or 500)
     for i, soln in enumerate(prolog.query("coins(S, %d, %d)." % (count, total))):
         S = zip(soln["S"], [1, 5, 10, 50, 100])
         print(i, end=" ")
         for c, v in S:
-            print("%dx%d" % (c, v), end=" ")
+            print(f"{c}x{v}", end=" ")
         print()
-    list(prolog.query("coins(S, %d, %d)." % (count, total)))
+    list(prolog.query(f"coins(S, {count}, {total})."))
 
 
 if __name__ == "__main__":

--- a/examples/coins/coins.py
+++ b/examples/coins/coins.py
@@ -23,6 +23,7 @@
 
 from pyswip.prolog import Prolog
 
+
 def main():
     prolog = Prolog()
     prolog.consult("coins.pl", relative_to=__file__)

--- a/examples/coins/coins_new.py
+++ b/examples/coins/coins_new.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
 #
@@ -23,19 +21,12 @@
 
 # 100 coins must sum to $5.00
 
-from __future__ import print_function
 from pyswip import Prolog, Functor, Variable, Query
-
-
-try:
-    input = raw_input
-except NameError:
-    pass
 
 
 def main():
     prolog = Prolog()
-    prolog.consult("coins.pl")
+    prolog.consult("coins.pl", relative_to=__file__)
     count = int(input("How many coins (default: 100)? ") or 100)
     total = int(input("What should be the total (default: 500)? ") or 500)
     coins = Functor("coins", 3)
@@ -47,7 +38,7 @@ def main():
         s = zip(S.value, [1, 5, 10, 50, 100])
         print(i, end=" ")
         for c, v in s:
-            print("%dx%d" % (c, v), end=" ")
+            print(f"{c}x{v}", end=" ")
         print()
         i += 1
     q.closeQuery()

--- a/examples/draughts/puzzle1.py
+++ b/examples/draughts/puzzle1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
 #
@@ -35,19 +33,12 @@
 # are four guards watching each wall.  How can they be rearranged such
 # that there are five watching each wall?"
 
-from __future__ import print_function
 from pyswip.prolog import Prolog
-
-
-try:
-    input = raw_input
-except NameError:
-    pass
 
 
 def main():
     prolog = Prolog()
-    prolog.consult("puzzle1.pl")
+    prolog.consult("puzzle1.pl", relative_to=__file__)
 
     for soln in prolog.query("solve(B)."):
         B = soln["B"]

--- a/examples/hanoi/hanoi.py
+++ b/examples/hanoi/hanoi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
 #
@@ -21,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import print_function
 from collections import deque
 
 from pyswip.prolog import Prolog
@@ -78,15 +75,13 @@ class Tower:
 
 
 def main():
-    N = 3
-    INTERACTIVITY = True
-
+    n = 3
     prolog = Prolog()
-    tower = Tower(N, INTERACTIVITY)
+    tower = Tower(n, True)
     notifier = Notifier(tower.move)
     registerForeign(notifier.notify)
-    prolog.consult("hanoi.pl")
-    list(prolog.query("hanoi(%d)" % N))
+    prolog.consult("hanoi.pl", relative_to=__file__)
+    list(prolog.query("hanoi(%d)" % n))
 
 
 if __name__ == "__main__":

--- a/examples/sendmoremoney/money.py
+++ b/examples/sendmoremoney/money.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
-
 # pyswip -- Python SWI-Prolog bridge
-# Copyright (c) 2007-2018 Yüce Tekol
+# Copyright (c) 2007-2024 Yüce Tekol
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,12 +27,11 @@
 # So, what should be the values of S, E, N, D, M, O, R, Y
 # if they are all distinct digits.
 
-from __future__ import print_function
 from pyswip import Prolog
 
-letters = "S E N D M O R Y".split()
+letters = list("SENDMORY")
 prolog = Prolog()
-prolog.consult("money.pl")
+prolog.consult("money.pl", relative_to=__file__)
 for result in prolog.query("sendmore(X)"):
     r = result["X"]
     for i, letter in enumerate(letters):

--- a/examples/sendmoremoney/money_new.py
+++ b/examples/sendmoremoney/money_new.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # pyswip -- Python SWI-Prolog bridge
 # Copyright (c) 2007-2018 Yüce Tekol
 #
@@ -29,15 +27,14 @@
 # So, what should be the values of S, E, N, D, M, O, R, Y
 # if they are all distinct digits.
 
-from __future__ import print_function
 from pyswip import Prolog, Functor, Variable, call
 
 
 def main():
-    letters = "S E N D M O R Y".split()
+    letters = list("SENDMORY")
     prolog = Prolog()
     sendmore = Functor("sendmore")
-    prolog.consult("money.pl")
+    prolog.consult("money.pl", relative_to=__file__)
 
     X = Variable()
     call(sendmore(X))

--- a/src/pyswip/__init__.py
+++ b/src/pyswip/__init__.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-
-
-# pyswip -- Python SWI-Prolog bridge
-# Copyright (c) 2007-2018 Yüce Tekol
+# Copyright (c) 2007-2024 Yüce Tekol and PySwip Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
-# PySwip version
 __VERSION__ = "0.3.1"
 
 from pyswip.prolog import Prolog as Prolog

--- a/src/pyswip/core.py
+++ b/src/pyswip/core.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-# pyswip -- Python SWI-Prolog bridge
-# Copyright (c) 2007-2018 Yüce Tekol
+# Copyright (c) 2007-2024 Yüce Tekol and PySwip Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,8 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from __future__ import print_function
 
 import atexit
 import glob

--- a/src/pyswip/easy.py
+++ b/src/pyswip/easy.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-# pyswip.easy -- PySwip helper functions
-# Copyright (c) 2007-2018 Yüce Tekol
+# Copyright (c) 2007-2024 Yüce Tekol and PySwip Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
 from pyswip.core import *
 
 
-# For backwards compability with Python 2 64bit
-if sys.version_info < (3,):
-    integer_types = (
-        int,
-        long,
-    )
-else:
-    integer_types = (int,)
+integer_types = (int,)
 
 
 class InvalidTypeError(TypeError):
@@ -146,17 +134,8 @@ class Term(object):
         return self.handle
 
 
-# support unicode also in python 2
-try:
-    isinstance("", basestring)
-
-    def isstr(s):
-        return isinstance(s, basestring)
-
-except NameError:
-
-    def isstr(s):
-        return isinstance(s, str)
+def isstr(s):
+    return isinstance(s, str)
 
 
 class Variable(object):

--- a/src/pyswip/prolog.py
+++ b/src/pyswip/prolog.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-# prolog.py -- Prolog class
-# Copyright (c) 2007-2012 Yüce Tekol
+# Copyright (c) 2007-2024 Yüce Tekol and PySwip Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +18,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Union
+from pathlib import Path
 
-from pyswip.core import *
-
+from pyswip.utils import resolve_path
+from pyswip.core import (
+    SWI_HOME_DIR, PL_STRING, REP_UTF8,
+    PL_Q_NODEBUG, PL_Q_CATCH_EXCEPTION, PL_Q_NORMAL,
+    PL_initialise, PL_open_foreign_frame, PL_new_term_ref,
+    PL_chars_to_term, PL_call, PL_discard_foreign_frame,
+    PL_new_term_refs, PL_put_chars, PL_predicate,
+    PL_open_query, PL_next_solution, PL_copy_term_ref,
+    PL_exception, PL_cut_query, PL_thread_self,
+    PL_thread_attach_engine,
+)
 
 class PrologError(Exception):
     pass
@@ -180,8 +187,9 @@ class Prolog:
         next(cls.query(term.join(["retractall((", "))."]), catcherrors=catcherrors))
 
     @classmethod
-    def consult(cls, filename, catcherrors=False):
-        next(cls.query(filename.join(["consult('", "')"]), catcherrors=catcherrors))
+    def consult(cls, filename: str, *, catcherrors=False, relative_to: Union[str, Path]=""):
+        path = resolve_path(filename, relative_to)
+        next(cls.query(str(path).join(["consult('", "')"]), catcherrors=catcherrors))
 
     @classmethod
     def query(cls, query, maxresult=-1, catcherrors=True, normalize=True):

--- a/src/pyswip/prolog.py
+++ b/src/pyswip/prolog.py
@@ -23,15 +23,30 @@ from pathlib import Path
 
 from pyswip.utils import resolve_path
 from pyswip.core import (
-    SWI_HOME_DIR, PL_STRING, REP_UTF8,
-    PL_Q_NODEBUG, PL_Q_CATCH_EXCEPTION, PL_Q_NORMAL,
-    PL_initialise, PL_open_foreign_frame, PL_new_term_ref,
-    PL_chars_to_term, PL_call, PL_discard_foreign_frame,
-    PL_new_term_refs, PL_put_chars, PL_predicate,
-    PL_open_query, PL_next_solution, PL_copy_term_ref,
-    PL_exception, PL_cut_query, PL_thread_self,
+    SWI_HOME_DIR,
+    PL_STRING,
+    REP_UTF8,
+    PL_Q_NODEBUG,
+    PL_Q_CATCH_EXCEPTION,
+    PL_Q_NORMAL,
+    PL_initialise,
+    PL_open_foreign_frame,
+    PL_new_term_ref,
+    PL_chars_to_term,
+    PL_call,
+    PL_discard_foreign_frame,
+    PL_new_term_refs,
+    PL_put_chars,
+    PL_predicate,
+    PL_open_query,
+    PL_next_solution,
+    PL_copy_term_ref,
+    PL_exception,
+    PL_cut_query,
+    PL_thread_self,
     PL_thread_attach_engine,
 )
+
 
 class PrologError(Exception):
     pass
@@ -187,7 +202,9 @@ class Prolog:
         next(cls.query(term.join(["retractall((", "))."]), catcherrors=catcherrors))
 
     @classmethod
-    def consult(cls, filename: str, *, catcherrors=False, relative_to: Union[str, Path]=""):
+    def consult(
+        cls, filename: str, *, catcherrors=False, relative_to: Union[str, Path] = ""
+    ):
         path = resolve_path(filename, relative_to)
         next(cls.query(str(path).join(["consult('", "')"]), catcherrors=catcherrors))
 

--- a/src/pyswip/utils.py
+++ b/src/pyswip/utils.py
@@ -28,7 +28,7 @@ def resolve_path(filename: str, relative_to: Union[str, Path] = "") -> Path:
     relative_to = Path(relative_to)
     if not relative_to.exists():
         raise FileNotFoundError(
-            None, f"resolve_filename: relative_to does not exist", str(relative_to)
+            None, "resolve_filename: relative_to does not exist", str(relative_to)
         )
     if relative_to.is_symlink():
         try:

--- a/src/pyswip/utils.py
+++ b/src/pyswip/utils.py
@@ -1,5 +1,4 @@
-# pyswip -- Python SWI-Prolog bridge
-# Copyright (c) 2007-2018 Yüce Tekol
+# Copyright (c) 2007-2024 Yüce Tekol and PySwip Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,23 +18,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from pyswip.prolog import Prolog
-from pyswip.easy import registerForeign
-
-N = 3  # Number of disks
+from typing import Union
+from pathlib import Path
 
 
-def main():
-    def notify(t):
-        print("move disk from %s pole to %s pole." % tuple(t))
+def resolve_path(filename: str, relative_to: Union[str, Path]= "") -> Path:
+    if not relative_to:
+        return Path(filename)
+    relative_to = Path(relative_to)
+    if not relative_to.exists():
+        raise FileNotFoundError(None, f"resolve_filename: relative_to does not exist", str(relative_to))
+    if relative_to.is_symlink():
+        try:
+            relative_to = relative_to.readlink()
+        except NotImplementedError:
+            pass
+    if relative_to.is_dir():
+        return relative_to / filename
+    elif relative_to.is_file():
+        return relative_to.parent / filename
+    raise ValueError("relative_to must be either a filename or a directory")
 
-    notify.arity = 1
-
-    prolog = Prolog()
-    registerForeign(notify)
-    prolog.consult("hanoi.pl", relative_to=__file__)
-    list(prolog.query(f"hanoi({N})"))
-
-
-if __name__ == "__main__":
-    main()

--- a/src/pyswip/utils.py
+++ b/src/pyswip/utils.py
@@ -28,13 +28,10 @@ def resolve_path(filename: str, relative_to: Union[str, Path] = "") -> Path:
     relative_to = Path(relative_to)
     if not relative_to.exists():
         raise FileNotFoundError(
-            None, "resolve_filename: relative_to does not exist", str(relative_to)
+            None, "Relative path does not exist", str(relative_to)
         )
     if relative_to.is_symlink():
-        try:
-            relative_to = relative_to.readlink()
-        except NotImplementedError:
-            pass
+        raise ValueError("Symbolic links are not supported")
     if relative_to.is_dir():
         return relative_to / filename
     elif relative_to.is_file():

--- a/src/pyswip/utils.py
+++ b/src/pyswip/utils.py
@@ -22,12 +22,14 @@ from typing import Union
 from pathlib import Path
 
 
-def resolve_path(filename: str, relative_to: Union[str, Path]= "") -> Path:
+def resolve_path(filename: str, relative_to: Union[str, Path] = "") -> Path:
     if not relative_to:
         return Path(filename)
     relative_to = Path(relative_to)
     if not relative_to.exists():
-        raise FileNotFoundError(None, f"resolve_filename: relative_to does not exist", str(relative_to))
+        raise FileNotFoundError(
+            None, f"resolve_filename: relative_to does not exist", str(relative_to)
+        )
     if relative_to.is_symlink():
         try:
             relative_to = relative_to.readlink()
@@ -38,4 +40,3 @@ def resolve_path(filename: str, relative_to: Union[str, Path]= "") -> Path:
     elif relative_to.is_file():
         return relative_to.parent / filename
     raise ValueError("relative_to must be either a filename or a directory")
-

--- a/src/pyswip/utils.py
+++ b/src/pyswip/utils.py
@@ -27,9 +27,7 @@ def resolve_path(filename: str, relative_to: Union[str, Path] = "") -> Path:
         return Path(filename)
     relative_to = Path(relative_to)
     if not relative_to.exists():
-        raise FileNotFoundError(
-            None, "Relative path does not exist", str(relative_to)
-        )
+        raise FileNotFoundError(None, "Relative path does not exist", str(relative_to))
     if relative_to.is_symlink():
         raise ValueError("Symbolic links are not supported")
     if relative_to.is_dir():

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -28,9 +28,6 @@
 import subprocess
 import sys
 import unittest
-import os
-
-current_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestIssues(unittest.TestCase):
@@ -250,8 +247,7 @@ class TestIssues(unittest.TestCase):
         from pyswip import Prolog
 
         prolog = Prolog()
-        path = os.path.join(current_dir, "test_unicode.pl")
-        prolog.consult(path, catcherrors=True)
+        prolog.consult("test_unicode.pl", catcherrors=True, relative_to=__file__)
         atoms = list(prolog.query("unicode_atom(B)."))
 
         self.assertEqual(len(atoms), 3, "Query should return exactly three atoms")
@@ -275,8 +271,7 @@ class TestIssues(unittest.TestCase):
         import pyswip.prolog as pl
 
         p = pl.Prolog()
-        path = os.path.join(current_dir, "test_functor_return.pl")
-        p.consult(path, catcherrors=True)
+        p.consult("test_functor_return.pl", catcherrors=True, relative_to=__file__)
         query = "sentence(Parse_tree, [the,bat,eats,a,cat], [])"
         expectedTree = "s(np(d(the), n(bat)), vp(v(eats), np(d(a), n(cat))))"
 

--- a/tests/test_prolog.py
+++ b/tests/test_prolog.py
@@ -30,7 +30,6 @@ import os.path
 import unittest
 
 import pyswip.prolog as pl  # This implicitly tests library loading code
-from tests.test_issues import current_dir
 
 
 class TestProlog(unittest.TestCase):
@@ -112,6 +111,7 @@ class TestProlog(unittest.TestCase):
         """
         See: https://github.com/yuce/pyswip/issues/10
         """
+        current_dir = os.path.dirname(os.path.abspath(__file__))
         prolog = pl.Prolog()
         path = os.path.join(current_dir, "test_read.pl")
         prolog.consult(path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,6 @@
 # SOFTWARE.
 
 import os
-import sys
 import unittest
 import tempfile
 from pathlib import Path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,61 @@
+# pyswip -- Python SWI-Prolog bridge
+# Copyright (c) 2007-2024 Yüce Tekol and PySwip
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import sys
+import unittest
+import tempfile
+from pathlib import Path
+
+from pyswip.utils import resolve_path
+
+
+class UtilsTestCase(unittest.TestCase):
+
+    def test_resolve_path_given_file(self):
+        filename = "test_read.pl"
+        path = resolve_path(filename)
+        self.assertEqual(Path(filename), path)
+
+    def test_resolve_path_given_dir(self):
+        filename = "test_read.pl"
+        path = resolve_path(filename, __file__)
+        current_dir = Path(__file__).parent.absolute()
+        self.assertEqual(current_dir / filename, path)
+
+    def test_resolve_path_symbolic_link(self):
+        if sys.platform == "win32":
+            self.skipTest("this feature is supported only on UNIX")
+        current_dir = Path(__file__).parent.absolute()
+        path = current_dir / "test_read.pl"
+        temp_dir = tempfile.TemporaryDirectory("pyswip")
+        try:
+            symlink = Path(temp_dir.name) / "symlinked"
+            os.symlink(path, symlink)
+            resolved_path = resolve_path("test_read.pl", symlink)
+            self.assertEqual(path, resolved_path)
+        finally:
+            temp_dir.cleanup()
+
+
+
+
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,15 +41,12 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(current_dir / filename, path)
 
     def test_resolve_path_symbolic_link(self):
-        if sys.platform == "win32":
-            self.skipTest("this feature is supported only on UNIX")
         current_dir = Path(__file__).parent.absolute()
         path = current_dir / "test_read.pl"
         temp_dir = tempfile.TemporaryDirectory("pyswip")
         try:
             symlink = Path(temp_dir.name) / "symlinked"
             os.symlink(path, symlink)
-            resolved_path = resolve_path("test_read.pl", symlink)
-            self.assertEqual(path, resolved_path)
+            self.assertRaises(ValueError, lambda: resolve_path("test_read.pl", symlink))
         finally:
             temp_dir.cleanup()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,6 @@ from pyswip.utils import resolve_path
 
 
 class UtilsTestCase(unittest.TestCase):
-
     def test_resolve_path_given_file(self):
         filename = "test_read.pl"
         path = resolve_path(filename)
@@ -54,8 +53,3 @@ class UtilsTestCase(unittest.TestCase):
             self.assertEqual(path, resolved_path)
         finally:
             temp_dir.cleanup()
-
-
-
-
-


### PR DESCRIPTION
This PR contains several enhancements to the `Prolog.consult` method.

## Tilde character in paths are expanded to the user home directory

```python
Prolog.consult("~/my_files/hanoi.pl")
# consults file /home/me/my_files/hanoi.pl
```

## Both strings and pathlib.Path objects are allowed as paths

```python
from pathlib import Path
Prolog.consult(Path("myfile.pl"))
# equivalent to:
Prolog.consult("myfile.pl")
```
## Added relative_to keyword argument

`relative_to` keyword argument makes it easier to construct the consult path.
This keyword is no-op, if the consult path is absolute.

If the given `relative_to` path is a file, then the consult path is updated to become a sibling of that path.
Assume you have the `/home/me/project/facts.pl` that you want to consult from the `run.py` file which exists in the same directory `/home/me/project`.
Using the built-in `__file__` constant which contains the path of the current Python file , it becomes very easy to do that:
```python
# in run.py
Prolog.consult("facts.pl", relative_to=__file__)
```

If the given `relative_path` is a directory, then the consult path is updated to become a child of that path.
```python
project_dir = "~/projects"
Prolog.consult("facts1.pl", relative_to=project_dir)
Prolog.consult("facts2.pl", relative_to=project_dir)
```

Symbolic links are not yet supported yet.
